### PR TITLE
Dpr2 1606 update dpds with reference type

### DIFF
--- a/src/main/resources/dev/definitions/prisons/clean/mis-multiple-prisoner-account-statements-monthly.json
+++ b/src/main/resources/dev/definitions/prisons/clean/mis-multiple-prisoner-account-statements-monthly.json
@@ -34,7 +34,7 @@
           "filterType": "autocomplete",
           "referenceType": "establishment",
           "reportFieldType": "string",
-          "display": "Establishment Code",
+          "display": "Establishment",
           "description": "@Prompt('Establishment Code','A','Establishment\\Establishment Code',mono,free,Not_Persistent,User:70)",
           "mandatory": "true"
         },
@@ -123,7 +123,7 @@
           "filterType": "autocomplete",
           "referenceType": "establishment",
           "reportFieldType": "string",
-          "display": "Establishment Code",
+          "display": "Establishment",
           "description": "@Prompt('Establishment Code','A','Establishment\\Establishment Code',mono,free,Not_Persistent,User:70)",
           "mandatory": "true"
         },
@@ -204,7 +204,7 @@
           "filterType": "autocomplete",
           "referenceType": "establishment",
           "reportFieldType": "string",
-          "display": "Establishment Code",
+          "display": "Establishment",
           "description": "@Prompt('Establishment Code','A','Establishment\\Establishment Code',mono,free,Not_Persistent,User:70)",
           "mandatory": "true"
         },

--- a/src/main/resources/dev/definitions/prisons/clean/mis-multiple-prisoner-account-statements-monthly.json
+++ b/src/main/resources/dev/definitions/prisons/clean/mis-multiple-prisoner-account-statements-monthly.json
@@ -31,7 +31,8 @@
         {
           "index": 0,
           "name": "establishment_code",
-          "filterType": "text",
+          "filterType": "autocomplete",
+          "referenceType": "establishment",
           "reportFieldType": "string",
           "display": "Establishment Code",
           "description": "@Prompt('Establishment Code','A','Establishment\\Establishment Code',mono,free,Not_Persistent,User:70)",
@@ -40,7 +41,8 @@
         {
           "index": 1,
           "name": "wing",
-          "filterType": "text",
+          "filterType": "autocomplete",
+          "referenceType": "wing",
           "reportFieldType": "string",
           "display": "Enter Wing (One Only)",
           "description": "@prompt('Enter Wing (One Only)','A','Cell\\Unit Description 1',Mono,Free,Not_Persistent,,User:0)",
@@ -118,7 +120,8 @@
         {
           "index": 0,
           "name": "establishment_code",
-          "filterType": "text",
+          "filterType": "autocomplete",
+          "referenceType": "establishment",
           "reportFieldType": "string",
           "display": "Establishment Code",
           "description": "@Prompt('Establishment Code','A','Establishment\\Establishment Code',mono,free,Not_Persistent,User:70)",
@@ -127,7 +130,8 @@
         {
           "index": 1,
           "name": "wing",
-          "filterType": "text",
+          "filterType": "autocomplete",
+          "referenceType": "wing",
           "reportFieldType": "string",
           "display": "Enter Wing (One Only)",
           "description": "@prompt('Enter Wing (One Only)','A','Cell\\Unit Description 1',Mono,Free,Not_Persistent,,User:0)",
@@ -197,7 +201,8 @@
         {
           "index": 0,
           "name": "establishment_code",
-          "filterType": "text",
+          "filterType": "autocomplete",
+          "referenceType": "establishment",
           "reportFieldType": "string",
           "display": "Establishment Code",
           "description": "@Prompt('Establishment Code','A','Establishment\\Establishment Code',mono,free,Not_Persistent,User:70)",
@@ -206,7 +211,8 @@
         {
           "index": 1,
           "name": "wing",
-          "filterType": "text",
+          "filterType": "autocomplete",
+          "referenceType": "wing",
           "reportFieldType": "string",
           "display": "Enter Wing (One Only)",
           "description": "@prompt('Enter Wing (One Only)','A','Cell\\Unit Description 1',Mono,Free,Not_Persistent,,User:0)",

--- a/src/main/resources/dev/definitions/prisons/clean/mis-omu-case-note-report-for-sentenced-prisoners.json
+++ b/src/main/resources/dev/definitions/prisons/clean/mis-omu-case-note-report-for-sentenced-prisoners.json
@@ -29,7 +29,8 @@
         {
           "index": 0,
           "name": "establishment_code",
-          "filterType": "text",
+          "filterType": "autocomplete",
+          "referenceType": "establishment",
           "reportFieldType": "string",
           "display": "Establishment Code (All for all)",
           "description": "@Prompt('Establishment Code (All for all)','A','Associated Establishment\\Associated Establishment Code',multi,free,Not_Persistent,User:69)",
@@ -50,7 +51,8 @@
         {
           "index": 0,
           "name": "establishment_code",
-          "filterType": "text",
+          "filterType": "autocomplete",
+          "referenceType": "establishment",
           "reportFieldType": "string",
           "display": "Establishment Code (All for all)",
           "description": "@Prompt('Establishment Code (All for all)','A','Associated Establishment\\Associated Establishment Code',multi,free,Not_Persistent,User:69)",
@@ -112,7 +114,8 @@
         {
           "index": 0,
           "name": "establishment_code",
-          "filterType": "text",
+          "filterType": "autocomplete",
+          "referenceType": "establishment",
           "reportFieldType": "string",
           "display": "Establishment Code (All for all)",
           "description": "@Prompt('Establishment Code (All for all)','A','Associated Establishment\\Associated Establishment Code',multi,free,Not_Persistent,User:69)",

--- a/src/main/resources/dev/definitions/prisons/clean/ors-age-breakdown-report.json
+++ b/src/main/resources/dev/definitions/prisons/clean/ors-age-breakdown-report.json
@@ -30,7 +30,7 @@
           "filterType": "autocomplete",
           "referenceType": "establishment",
           "reportFieldType": "string",
-          "display": "Establishment Code",
+          "display": "Establishment",
           "description": "@Prompt('Establishment Code','A','Establishment\\Establishment Code',mono,free,,Not_Persistent,,User:3)",
           "mandatory": "true"
         },

--- a/src/main/resources/dev/definitions/prisons/clean/ors-age-breakdown-report.json
+++ b/src/main/resources/dev/definitions/prisons/clean/ors-age-breakdown-report.json
@@ -27,7 +27,8 @@
         {
           "index": 0,
           "name": "establishment_code",
-          "filterType": "text",
+          "filterType": "autocomplete",
+          "referenceType": "establishment",
           "reportFieldType": "string",
           "display": "Establishment Code",
           "description": "@Prompt('Establishment Code','A','Establishment\\Establishment Code',mono,free,,Not_Persistent,,User:3)",
@@ -36,7 +37,8 @@
         {
           "index": 1,
           "name": "wing",
-          "filterType": "text",
+          "filterType": "autocomplete",
+          "referenceType": "wing",
           "reportFieldType": "string",
           "display": "Wing (All for all)",
           "description": "@Prompt('Wing (All for all)','A','Cell\\Level 1 Living Unit LOV',multi,free,,Not_Persistent,,User:4)",

--- a/src/main/resources/dev/definitions/prisons/clean/ors-case-notes-update-report.json
+++ b/src/main/resources/dev/definitions/prisons/clean/ors-case-notes-update-report.json
@@ -30,7 +30,7 @@
           "filterType": "autocomplete",
           "referenceType": "establishment",
           "reportFieldType": "string",
-          "display": "Establishment Code",
+          "display": "Establishment",
           "description": "@Prompt('Establishment Code','A','Establishment\\Establishment Code',mono,free,,Not_Persistent,,User:3)",
           "mandatory": "true"
         },

--- a/src/main/resources/dev/definitions/prisons/clean/ors-case-notes-update-report.json
+++ b/src/main/resources/dev/definitions/prisons/clean/ors-case-notes-update-report.json
@@ -27,7 +27,8 @@
         {
           "index": 0,
           "name": "establishment_code",
-          "filterType": "text",
+          "filterType": "autocomplete",
+          "referenceType": "establishment",
           "reportFieldType": "string",
           "display": "Establishment Code",
           "description": "@Prompt('Establishment Code','A','Establishment\\Establishment Code',mono,free,,Not_Persistent,,User:3)",
@@ -36,7 +37,8 @@
         {
           "index": 1,
           "name": "wing",
-          "filterType": "text",
+          "filterType": "autocomplete",
+          "referenceType": "wing",
           "reportFieldType": "string",
           "display": "Wing (All for all)",
           "description": "@Prompt('Wing (All for all)','A','Cell\\Level 1 Living Unit LOV',multi,free,,Not_Persistent,,User:4)",

--- a/src/main/resources/dev/definitions/prisons/clean/ors-convicted-prisoners-missing-entry-iep.json
+++ b/src/main/resources/dev/definitions/prisons/clean/ors-convicted-prisoners-missing-entry-iep.json
@@ -30,7 +30,7 @@
           "filterType": "autocomplete",
           "referenceType": "establishment",
           "reportFieldType": "string",
-          "display": "Establishment Code",
+          "display": "Establishment",
           "description": "@Prompt('Establishment Code','A','Establishment\\Establishment Code',mono,free,,Not_Persistent,,User:3)",
           "mandatory": "true"
         }
@@ -141,7 +141,7 @@
           "filterType": "autocomplete",
           "referenceType": "establishment",
           "reportFieldType": "string",
-          "display": "Establishment Code",
+          "display": "Establishment",
           "description": "@Prompt('Establishment Code','A','Establishment\\Establishment Code',mono,free,,Not_Persistent,,User:3)",
           "mandatory": "true"
         }

--- a/src/main/resources/dev/definitions/prisons/clean/ors-convicted-prisoners-missing-entry-iep.json
+++ b/src/main/resources/dev/definitions/prisons/clean/ors-convicted-prisoners-missing-entry-iep.json
@@ -27,7 +27,8 @@
         {
           "index": 0,
           "name": "establishment_code",
-          "filterType": "text",
+          "filterType": "autocomplete",
+          "referenceType": "establishment",
           "reportFieldType": "string",
           "display": "Establishment Code",
           "description": "@Prompt('Establishment Code','A','Establishment\\Establishment Code',mono,free,,Not_Persistent,,User:3)",
@@ -137,7 +138,8 @@
         {
           "index": 0,
           "name": "establishment_code",
-          "filterType": "text",
+          "filterType": "autocomplete",
+          "referenceType": "establishment",
           "reportFieldType": "string",
           "display": "Establishment Code",
           "description": "@Prompt('Establishment Code','A','Establishment\\Establishment Code',mono,free,,Not_Persistent,,User:3)",

--- a/src/main/resources/dev/definitions/prisons/clean/ors-count-of-prisoners-with-disabilities.json
+++ b/src/main/resources/dev/definitions/prisons/clean/ors-count-of-prisoners-with-disabilities.json
@@ -36,7 +36,8 @@
         {
           "index": 1,
           "name": "establishment_code",
-          "filterType": "text",
+          "filterType": "autocomplete",
+          "referenceType": "establishment",
           "reportFieldType": "string",
           "display": "Establishment Code (All for all)",
           "description": "@Prompt('Establishment Code (All for all)','A','Establishment\\Establishment Code',multi,free,,Not_Persistent,,User:3)",
@@ -82,7 +83,8 @@
         {
           "index": 0,
           "name": "establishment_code",
-          "filterType": "text",
+          "filterType": "autocomplete",
+          "referenceType": "establishment",
           "reportFieldType": "string",
           "display": "Establishment Code (All for all)",
           "description": "@Prompt('Establishment Code (All for all)','A','Establishment\\Establishment Code',multi,free,,Not_Persistent,,User:3)",
@@ -120,7 +122,8 @@
         {
           "index": 0,
           "name": "establishment_code",
-          "filterType": "text",
+          "filterType": "autocomplete",
+          "referenceType": "establishment",
           "reportFieldType": "string",
           "display": "Establishment Code (All for all)",
           "description": "@Prompt('Establishment Code (All for all)','A','Establishment\\Establishment Code',multi,free,,Not_Persistent,,User:3)",
@@ -158,7 +161,8 @@
         {
           "index": 0,
           "name": "establishment_code",
-          "filterType": "text",
+          "filterType": "autocomplete",
+          "referenceType": "establishment",
           "reportFieldType": "string",
           "display": "Establishment Code (All for all)",
           "description": "@Prompt('Establishment Code (All for all)','A','Establishment\\Establishment Code',multi,free,,Not_Persistent,,User:3)",
@@ -196,7 +200,8 @@
         {
           "index": 0,
           "name": "establishment_code",
-          "filterType": "text",
+          "filterType": "autocomplete",
+          "referenceType": "establishment",
           "reportFieldType": "string",
           "display": "Establishment Code (All for all)",
           "description": "@Prompt('Establishment Code (All for all)','A','Establishment\\Establishment Code',multi,free,,Not_Persistent,,User:3)",
@@ -234,7 +239,8 @@
         {
           "index": 0,
           "name": "establishment_code",
-          "filterType": "text",
+          "filterType": "autocomplete",
+          "referenceType": "establishment",
           "reportFieldType": "string",
           "display": "Establishment Code (All for all)",
           "description": "@Prompt('Establishment Code (All for all)','A','Establishment\\Establishment Code',multi,free,,Not_Persistent,,User:3)",
@@ -264,7 +270,8 @@
         {
           "index": 0,
           "name": "establishment_code",
-          "filterType": "text",
+          "filterType": "autocomplete",
+          "referenceType": "establishment",
           "reportFieldType": "string",
           "display": "Establishment Code (All for all)",
           "description": "@Prompt('Establishment Code (All for all)','A','Establishment\\Establishment Code',multi,free,,Not_Persistent,,User:3)",
@@ -302,7 +309,8 @@
         {
           "index": 0,
           "name": "establishment_code",
-          "filterType": "text",
+          "filterType": "autocomplete",
+          "referenceType": "establishment",
           "reportFieldType": "string",
           "display": "Establishment Code (All for all)",
           "description": "@Prompt('Establishment Code (All for all)','A','Establishment\\Establishment Code',multi,free,,Not_Persistent,,User:3)",

--- a/src/main/resources/dev/definitions/prisons/clean/ors-csra-report-or.json
+++ b/src/main/resources/dev/definitions/prisons/clean/ors-csra-report-or.json
@@ -29,7 +29,8 @@
         {
           "index": 0,
           "name": "establishment_code",
-          "filterType": "text",
+          "filterType": "autocomplete",
+          "referenceType": "establishment",
           "reportFieldType": "string",
           "display": "Establishment Code(s)",
           "description": "@Prompt('Establishment Code(s)','A','Establishment\\Establishment Code',multi,free,,Not_Persistent,,User:3)",
@@ -38,7 +39,8 @@
         {
           "index": 1,
           "name": "wing",
-          "filterType": "text",
+          "filterType": "autocomplete",
+          "referenceType": "wing",
           "reportFieldType": "string",
           "display": "Wing (All for all)",
           "description": "@Prompt('Wing (All for all)','A','Cell\\Location LOV',multi,free,,Not_Persistent,,User:4)",

--- a/src/main/resources/dev/definitions/prisons/clean/ors-diary-check-list-report.json
+++ b/src/main/resources/dev/definitions/prisons/clean/ors-diary-check-list-report.json
@@ -30,7 +30,7 @@
           "filterType": "autocomplete",
           "referenceType": "establishment",
           "reportFieldType": "string",
-          "display": "Establishment Code",
+          "display": "Establishment",
           "description": "@Prompt('Establishment Code','A','Establishment\\Establishment Code',mono,free,,Not_Persistent,,User:3)",
           "mandatory": "true"
         },
@@ -255,7 +255,7 @@
           "filterType": "autocomplete",
           "referenceType": "establishment",
           "reportFieldType": "string",
-          "display": "Establishment Code",
+          "display": "Establishment",
           "description": "@Prompt('Establishment Code','A','Establishment\\Establishment Code',mono,free,,Not_Persistent,,User:3)",
           "mandatory": "true"
         },

--- a/src/main/resources/dev/definitions/prisons/clean/ors-diary-check-list-report.json
+++ b/src/main/resources/dev/definitions/prisons/clean/ors-diary-check-list-report.json
@@ -27,7 +27,8 @@
         {
           "index": 0,
           "name": "establishment_code",
-          "filterType": "text",
+          "filterType": "autocomplete",
+          "referenceType": "establishment",
           "reportFieldType": "string",
           "display": "Establishment Code",
           "description": "@Prompt('Establishment Code','A','Establishment\\Establishment Code',mono,free,,Not_Persistent,,User:3)",
@@ -251,7 +252,8 @@
         {
           "index": 0,
           "name": "establishment_code",
-          "filterType": "text",
+          "filterType": "autocomplete",
+          "referenceType": "establishment",
           "reportFieldType": "string",
           "display": "Establishment Code",
           "description": "@Prompt('Establishment Code','A','Establishment\\Establishment Code',mono,free,,Not_Persistent,,User:3)",

--- a/src/main/resources/dev/definitions/prisons/clean/ors-i2t-gang-affiliations-extract.json
+++ b/src/main/resources/dev/definitions/prisons/clean/ors-i2t-gang-affiliations-extract.json
@@ -45,7 +45,7 @@
           "filterType": "autocomplete",
           "referenceType": "establishment",
           "reportFieldType": "string",
-          "display": "Establishment Code",
+          "display": "Establishment",
           "description": "@prompt('Establishment Code','A','Establishment\\Establishment Code',Multi,Free,Not_Persistent,,User:0)",
           "mandatory": "true"
         }

--- a/src/main/resources/dev/definitions/prisons/clean/ors-i2t-gang-affiliations-extract.json
+++ b/src/main/resources/dev/definitions/prisons/clean/ors-i2t-gang-affiliations-extract.json
@@ -32,7 +32,8 @@
         {
           "index": 0,
           "name": "wing",
-          "filterType": "text",
+          "filterType": "autocomplete",
+          "referenceType": "wing",
           "reportFieldType": "string",
           "display": "Wing (All for all)",
           "description": "@Prompt('Wing (All for all)','A','Cell\\Level 1 Living Unit LOV',multi,free,,Not_Persistent,,User:4)",
@@ -41,7 +42,8 @@
         {
           "index": 1,
           "name": "establishment_code",
-          "filterType": "text",
+          "filterType": "autocomplete",
+          "referenceType": "establishment",
           "reportFieldType": "string",
           "display": "Establishment Code",
           "description": "@prompt('Establishment Code','A','Establishment\\Establishment Code',Multi,Free,Not_Persistent,,User:0)",

--- a/src/main/resources/dev/definitions/prisons/clean/ors-i2t-non-association-list.json
+++ b/src/main/resources/dev/definitions/prisons/clean/ors-i2t-non-association-list.json
@@ -27,7 +27,8 @@
         {
           "index": 0,
           "name": "establishment_code",
-          "filterType": "text",
+          "filterType": "autocomplete",
+          "referenceType": "establishment",
           "reportFieldType": "string",
           "display": "Establishment Code (All for all)",
           "description": "@Prompt('Establishment Code (All for all)','A','Establishment\\Establishment Code',multi,free,,Not_Persistent,,User:3)",

--- a/src/main/resources/dev/definitions/prisons/clean/ors-iep-error-report.json
+++ b/src/main/resources/dev/definitions/prisons/clean/ors-iep-error-report.json
@@ -27,7 +27,8 @@
         {
           "index": 0,
           "name": "establishment_code",
-          "filterType": "text",
+          "filterType": "autocomplete",
+          "referenceType": "establishment",
           "reportFieldType": "string",
           "display": "Establishment Code",
           "description": "@Prompt('Establishment Code','A','Establishment\\Establishment Code',mono,free,,Not_Persistent,,User:3)",

--- a/src/main/resources/dev/definitions/prisons/clean/ors-iep-error-report.json
+++ b/src/main/resources/dev/definitions/prisons/clean/ors-iep-error-report.json
@@ -30,7 +30,7 @@
           "filterType": "autocomplete",
           "referenceType": "establishment",
           "reportFieldType": "string",
-          "display": "Establishment Code",
+          "display": "Establishment",
           "description": "@Prompt('Establishment Code','A','Establishment\\Establishment Code',mono,free,,Not_Persistent,,User:3)",
           "mandatory": "true"
         }

--- a/src/main/resources/dev/definitions/prisons/clean/ors-local-administrators.json
+++ b/src/main/resources/dev/definitions/prisons/clean/ors-local-administrators.json
@@ -27,7 +27,8 @@
         {
           "index": 0,
           "name": "establishment_code",
-          "filterType": "text",
+          "filterType": "autocomplete",
+          "referenceType": "establishment",
           "reportFieldType": "string",
           "display": "Establishment Code (All for all)",
           "description": "@Prompt('Establishment Code (All for all)','A','Local Administrators\\LAA Establishment Code',multi,free,,Not_Persistent,,User:3)",

--- a/src/main/resources/dev/definitions/prisons/clean/ors-national-alerts-report.json
+++ b/src/main/resources/dev/definitions/prisons/clean/ors-national-alerts-report.json
@@ -29,7 +29,8 @@
         {
           "index": 0,
           "name": "establishment_code",
-          "filterType": "text",
+          "filterType": "autocomplete",
+          "referenceType": "establishment",
           "reportFieldType": "string",
           "display": "Establishment Code (All for all)",
           "description": "@Prompt('Establishment Code (All for all)','A','Establishment\\Establishment Code',multi,free,,Not_Persistent,,User:3)",

--- a/src/main/resources/dev/definitions/prisons/clean/ors-national-report-of-booked-visits.json
+++ b/src/main/resources/dev/definitions/prisons/clean/ors-national-report-of-booked-visits.json
@@ -90,7 +90,8 @@
         {
           "index": 0,
           "name": "establishment_code",
-          "filterType": "text",
+          "filterType": "autocomplete",
+          "referenceType": "establishment",
           "reportFieldType": "string",
           "display": "Establishment Code (All for all)",
           "description": "@Prompt('Establishment Code (All for all)','A','Establishment\\Establishment Code',multi,free,,Not_Persistent,,User:3)",

--- a/src/main/resources/dev/definitions/prisons/clean/ors-prisoners-at-court-area-manager.json
+++ b/src/main/resources/dev/definitions/prisons/clean/ors-prisoners-at-court-area-manager.json
@@ -27,7 +27,8 @@
         {
           "index": 0,
           "name": "establishment_code",
-          "filterType": "text",
+          "filterType": "autocomplete",
+          "referenceType": "establishment",
           "reportFieldType": "string",
           "display": "Establishment Code",
           "description": "@Prompt('Establishment Code','A','Establishment\\Establishment Code',mono,free,,Not_Persistent,,User:3)",

--- a/src/main/resources/dev/definitions/prisons/clean/ors-prisoners-at-court-area-manager.json
+++ b/src/main/resources/dev/definitions/prisons/clean/ors-prisoners-at-court-area-manager.json
@@ -30,7 +30,7 @@
           "filterType": "autocomplete",
           "referenceType": "establishment",
           "reportFieldType": "string",
-          "display": "Establishment Code",
+          "display": "Establishment",
           "description": "@Prompt('Establishment Code','A','Establishment\\Establishment Code',mono,free,,Not_Persistent,,User:3)",
           "mandatory": "true"
         }

--- a/src/main/resources/dev/definitions/prisons/clean/ors-prisoners-at-court.json
+++ b/src/main/resources/dev/definitions/prisons/clean/ors-prisoners-at-court.json
@@ -27,7 +27,8 @@
         {
           "index": 0,
           "name": "establishment_code",
-          "filterType": "text",
+          "filterType": "autocomplete",
+          "referenceType": "establishment",
           "reportFieldType": "string",
           "display": "Establishment Code",
           "description": "@Prompt('Establishment Code','A','Establishment\\Establishment Code',mono,free,,Not_Persistent,,User:3)",

--- a/src/main/resources/dev/definitions/prisons/clean/ors-prisoners-at-court.json
+++ b/src/main/resources/dev/definitions/prisons/clean/ors-prisoners-at-court.json
@@ -30,7 +30,7 @@
           "filterType": "autocomplete",
           "referenceType": "establishment",
           "reportFieldType": "string",
-          "display": "Establishment Code",
+          "display": "Establishment",
           "description": "@Prompt('Establishment Code','A','Establishment\\Establishment Code',mono,free,,Not_Persistent,,User:3)",
           "mandatory": "true"
         }

--- a/src/main/resources/dev/definitions/prisons/clean/ors-prisoners-in-reception-court-or-cswap-more-than-a-day-with-additional-grace-period.json
+++ b/src/main/resources/dev/definitions/prisons/clean/ors-prisoners-in-reception-court-or-cswap-more-than-a-day-with-additional-grace-period.json
@@ -27,7 +27,8 @@
         {
           "index": 0,
           "name": "establishment_code",
-          "filterType": "text",
+          "filterType": "autocomplete",
+          "referenceType": "establishment",
           "reportFieldType": "string",
           "display": "Establishment Code",
           "description": "@Prompt('Establishment Code','A','Establishment\\Establishment Code',mono,free,,Not_Persistent,,User:3)",

--- a/src/main/resources/dev/definitions/prisons/clean/ors-prisoners-in-reception-court-or-cswap-more-than-a-day-with-additional-grace-period.json
+++ b/src/main/resources/dev/definitions/prisons/clean/ors-prisoners-in-reception-court-or-cswap-more-than-a-day-with-additional-grace-period.json
@@ -30,7 +30,7 @@
           "filterType": "autocomplete",
           "referenceType": "establishment",
           "reportFieldType": "string",
-          "display": "Establishment Code",
+          "display": "Establishment",
           "description": "@Prompt('Establishment Code','A','Establishment\\Establishment Code',mono,free,,Not_Persistent,,User:3)",
           "mandatory": "true"
         }

--- a/src/main/resources/dev/definitions/prisons/clean/ors-property-box-allocation-to-active-prisoners.json
+++ b/src/main/resources/dev/definitions/prisons/clean/ors-property-box-allocation-to-active-prisoners.json
@@ -30,7 +30,7 @@
           "filterType": "autocomplete",
           "referenceType": "establishment",
           "reportFieldType": "string",
-          "display": "Establishment Code",
+          "display": "Establishment",
           "description": "@Prompt('Establishment Code','A','Establishment\\Establishment Code',mono,free,,Not_Persistent,,User:3)",
           "mandatory": "true"
         }
@@ -133,7 +133,7 @@
           "filterType": "autocomplete",
           "referenceType": "establishment",
           "reportFieldType": "string",
-          "display": "Establishment Code",
+          "display": "Establishment",
           "description": "@prompt('Establishment Code','A','Establishment\\Establishment Code',Mono,Free,Not_Persistent,,User:0)",
           "mandatory": "true"
         }

--- a/src/main/resources/dev/definitions/prisons/clean/ors-property-box-allocation-to-active-prisoners.json
+++ b/src/main/resources/dev/definitions/prisons/clean/ors-property-box-allocation-to-active-prisoners.json
@@ -27,7 +27,8 @@
         {
           "index": 0,
           "name": "establishment_code",
-          "filterType": "text",
+          "filterType": "autocomplete",
+          "referenceType": "establishment",
           "reportFieldType": "string",
           "display": "Establishment Code",
           "description": "@Prompt('Establishment Code','A','Establishment\\Establishment Code',mono,free,,Not_Persistent,,User:3)",
@@ -129,7 +130,8 @@
         {
           "index": 0,
           "name": "establishment_code",
-          "filterType": "text",
+          "filterType": "autocomplete",
+          "referenceType": "establishment",
           "reportFieldType": "string",
           "display": "Establishment Code",
           "description": "@prompt('Establishment Code','A','Establishment\\Establishment Code',Mono,Free,Not_Persistent,,User:0)",

--- a/src/main/resources/dev/definitions/prisons/clean/ors-scheduled-prison-activities.json
+++ b/src/main/resources/dev/definitions/prisons/clean/ors-scheduled-prison-activities.json
@@ -27,7 +27,8 @@
         {
           "index": 0,
           "name": "establishment_code",
-          "filterType": "text",
+          "filterType": "autocomplete",
+          "referenceType": "establishment",
           "reportFieldType": "string",
           "display": "Enter Activity Establishment Code:",
           "description": "@prompt('Enter Activity Establishment Code:','A','Prison Activities\\Activity Establishment Code',Mono,Free,Not_Persistent,,User:0)",

--- a/src/main/resources/dev/definitions/prisons/clean/ors-temporary-absence-and-home-leave-return-dates.json
+++ b/src/main/resources/dev/definitions/prisons/clean/ors-temporary-absence-and-home-leave-return-dates.json
@@ -45,7 +45,8 @@
         {
           "index": 2,
           "name": "establishment_code",
-          "filterType": "text",
+          "filterType": "autocomplete",
+          "referenceType": "establishment",
           "reportFieldType": "string",
           "display": "Establishment Code",
           "description": "@prompt('Establishment Code','A','TAP Return\\Returning To Establishment Code',Mono,Free,Not_Persistent,,User:2)",

--- a/src/main/resources/dev/definitions/prisons/clean/ors-temporary-absence-and-home-leave-return-dates.json
+++ b/src/main/resources/dev/definitions/prisons/clean/ors-temporary-absence-and-home-leave-return-dates.json
@@ -48,7 +48,7 @@
           "filterType": "autocomplete",
           "referenceType": "establishment",
           "reportFieldType": "string",
-          "display": "Establishment Code",
+          "display": "Establishment",
           "description": "@prompt('Establishment Code','A','TAP Return\\Returning To Establishment Code',Mono,Free,Not_Persistent,,User:2)",
           "mandatory": "true"
         }

--- a/src/main/resources/dev/definitions/prisons/clean/ors-transfer-holds-report.json
+++ b/src/main/resources/dev/definitions/prisons/clean/ors-transfer-holds-report.json
@@ -30,7 +30,7 @@
           "filterType": "autocomplete",
           "referenceType": "establishment",
           "reportFieldType": "string",
-          "display": "Establishment Code",
+          "display": "Establishment",
           "description": "@Prompt('Establishment Code','A','Establishment\\Establishment Code',mono,free,,Not_Persistent,,User:3)",
           "mandatory": "true"
         },

--- a/src/main/resources/dev/definitions/prisons/clean/ors-transfer-holds-report.json
+++ b/src/main/resources/dev/definitions/prisons/clean/ors-transfer-holds-report.json
@@ -27,7 +27,8 @@
         {
           "index": 0,
           "name": "establishment_code",
-          "filterType": "text",
+          "filterType": "autocomplete",
+          "referenceType": "establishment",
           "reportFieldType": "string",
           "display": "Establishment Code",
           "description": "@Prompt('Establishment Code','A','Establishment\\Establishment Code',mono,free,,Not_Persistent,,User:3)",
@@ -36,7 +37,8 @@
         {
           "index": 1,
           "name": "wing",
-          "filterType": "text",
+          "filterType": "autocomplete",
+          "referenceType": "wing",
           "reportFieldType": "string",
           "display": "Wing (All for all)",
           "description": "@Prompt('Wing (All for all)','A','Cell\\Location LOV',multi,free,,Not_Persistent,,User:4)",

--- a/src/main/resources/dev/definitions/prisons/clean/ors-visit-history-for-a-prisoner.json
+++ b/src/main/resources/dev/definitions/prisons/clean/ors-visit-history-for-a-prisoner.json
@@ -36,7 +36,8 @@
         {
           "index": 1,
           "name": "establishment_code",
-          "filterType": "text",
+          "filterType": "autocomplete",
+          "referenceType": "establishment",
           "reportFieldType": "string",
           "display": "Establishment Code",
           "description": "@Prompt('Establishment Code','A','Establishment\\Establishment Code',mono,free,,Not_Persistent,,User:3)",

--- a/src/main/resources/dev/definitions/prisons/clean/ors-visit-history-for-a-prisoner.json
+++ b/src/main/resources/dev/definitions/prisons/clean/ors-visit-history-for-a-prisoner.json
@@ -39,7 +39,7 @@
           "filterType": "autocomplete",
           "referenceType": "establishment",
           "reportFieldType": "string",
-          "display": "Establishment Code",
+          "display": "Establishment",
           "description": "@Prompt('Establishment Code','A','Establishment\\Establishment Code',mono,free,,Not_Persistent,,User:3)",
           "mandatory": "true"
         }

--- a/src/main/resources/dev/definitions/prisons/clean/ors-visit-orders-remaining.json
+++ b/src/main/resources/dev/definitions/prisons/clean/ors-visit-orders-remaining.json
@@ -27,7 +27,8 @@
         {
           "index": 0,
           "name": "establishment_code",
-          "filterType": "text",
+          "filterType": "autocomplete",
+          "referenceType": "establishment",
           "reportFieldType": "string",
           "display": "Establishment Code",
           "description": "@Prompt('Establishment Code','A','Establishment\\Establishment Code',mono,free,,Not_Persistent,,User:3)",

--- a/src/main/resources/dev/definitions/prisons/clean/ors-visit-orders-remaining.json
+++ b/src/main/resources/dev/definitions/prisons/clean/ors-visit-orders-remaining.json
@@ -30,7 +30,7 @@
           "filterType": "autocomplete",
           "referenceType": "establishment",
           "reportFieldType": "string",
-          "display": "Establishment Code",
+          "display": "Establishment",
           "description": "@Prompt('Establishment Code','A','Establishment\\Establishment Code',mono,free,,Not_Persistent,,User:3)",
           "mandatory": "true"
         }

--- a/src/main/resources/dev/definitions/prisons/orphanage/national-social-visit-report.json
+++ b/src/main/resources/dev/definitions/prisons/orphanage/national-social-visit-report.json
@@ -43,7 +43,8 @@
         {
           "index": 2,
           "name": "establishment_code",
-          "filterType": "text",
+          "filterType": "autocomplete",
+          "referenceType": "establishment",
           "reportFieldType": "string",
           "display": "Enter value for Visit Establishment Code",
           "description": "@prompt('Enter value for Visit Establishment Code','A','Visits\\Visit Establishment Code',Multi,Free,Not_Persistent,,User:2)",

--- a/src/main/resources/dev/definitions/prisons/orphanage/ors-a-and-o-contingency-report.json
+++ b/src/main/resources/dev/definitions/prisons/orphanage/ors-a-and-o-contingency-report.json
@@ -25,7 +25,8 @@
         {
           "index": 0,
           "name": "establishment_code",
-          "filterType": "text",
+          "filterType": "autocomplete",
+          "referenceType": "establishment",
           "reportFieldType": "string",
           "display": "Establishment Code",
           "description": "@Prompt('Establishment Code','A','Establishment\\Establishment Code',mono,free,,Not_Persistent,,User:3)",

--- a/src/main/resources/dev/definitions/prisons/orphanage/ors-a-and-o-contingency-report.json
+++ b/src/main/resources/dev/definitions/prisons/orphanage/ors-a-and-o-contingency-report.json
@@ -28,7 +28,7 @@
           "filterType": "autocomplete",
           "referenceType": "establishment",
           "reportFieldType": "string",
-          "display": "Establishment Code",
+          "display": "Establishment",
           "description": "@Prompt('Establishment Code','A','Establishment\\Establishment Code',mono,free,,Not_Persistent,,User:3)",
           "mandatory": "true"
         }

--- a/src/main/resources/dev/definitions/prisons/orphanage/ors-admissions.json
+++ b/src/main/resources/dev/definitions/prisons/orphanage/ors-admissions.json
@@ -25,7 +25,8 @@
         {
           "index": 0,
           "name": "establishment_code",
-          "filterType": "text",
+          "filterType": "autocomplete",
+          "referenceType": "establishment",
           "reportFieldType": "string",
           "display": "Establishment Code",
           "description": "@prompt('Establishment Code','A','Establishment\\Establishment Code',Mono,Free,Not_Persistent,,User:0)",
@@ -201,7 +202,8 @@
         {
           "index": 0,
           "name": "establishment_code",
-          "filterType": "text",
+          "filterType": "autocomplete",
+          "referenceType": "establishment",
           "reportFieldType": "string",
           "display": "Establishment Code",
           "description": "@prompt('Establishment Code','A','Establishment\\Establishment Code',Mono,Free,Not_Persistent,,User:0)",
@@ -257,7 +259,8 @@
         {
           "index": 0,
           "name": "establishment_code",
-          "filterType": "text",
+          "filterType": "autocomplete",
+          "referenceType": "establishment",
           "reportFieldType": "string",
           "display": "Establishment Code",
           "description": "@prompt('Establishment Code','A','Establishment\\Establishment Code',Mono,Free,Not_Persistent,,User:0)",

--- a/src/main/resources/dev/definitions/prisons/orphanage/ors-admissions.json
+++ b/src/main/resources/dev/definitions/prisons/orphanage/ors-admissions.json
@@ -28,7 +28,7 @@
           "filterType": "autocomplete",
           "referenceType": "establishment",
           "reportFieldType": "string",
-          "display": "Establishment Code",
+          "display": "Establishment",
           "description": "@prompt('Establishment Code','A','Establishment\\Establishment Code',Mono,Free,Not_Persistent,,User:0)",
           "mandatory": "true"
         },
@@ -205,7 +205,7 @@
           "filterType": "autocomplete",
           "referenceType": "establishment",
           "reportFieldType": "string",
-          "display": "Establishment Code",
+          "display": "Establishment",
           "description": "@prompt('Establishment Code','A','Establishment\\Establishment Code',Mono,Free,Not_Persistent,,User:0)",
           "mandatory": "true"
         },
@@ -262,7 +262,7 @@
           "filterType": "autocomplete",
           "referenceType": "establishment",
           "reportFieldType": "string",
-          "display": "Establishment Code",
+          "display": "Establishment",
           "description": "@prompt('Establishment Code','A','Establishment\\Establishment Code',Mono,Free,Not_Persistent,,User:0)",
           "mandatory": "true"
         },

--- a/src/main/resources/dev/definitions/prisons/orphanage/ors-alerts-report.json
+++ b/src/main/resources/dev/definitions/prisons/orphanage/ors-alerts-report.json
@@ -28,7 +28,8 @@
         {
           "index": 0,
           "name": "establishment_code",
-          "filterType": "text",
+          "filterType": "autocomplete",
+          "referenceType": "establishment",
           "reportFieldType": "string",
           "display": "Establishment Code",
           "description": "",
@@ -37,7 +38,8 @@
         {
           "index": 1,
           "name": "wing",
-          "filterType": "text",
+          "filterType": "autocomplete",
+          "referenceType": "wing",
           "reportFieldType": "string",
           "display": "Wing (All for all)",
           "description": "",

--- a/src/main/resources/dev/definitions/prisons/orphanage/ors-alerts-report.json
+++ b/src/main/resources/dev/definitions/prisons/orphanage/ors-alerts-report.json
@@ -31,7 +31,7 @@
           "filterType": "autocomplete",
           "referenceType": "establishment",
           "reportFieldType": "string",
-          "display": "Establishment Code",
+          "display": "Establishment",
           "description": "",
           "mandatory": "true"
         },

--- a/src/main/resources/dev/definitions/prisons/orphanage/ors-alternative-unlock-list.json
+++ b/src/main/resources/dev/definitions/prisons/orphanage/ors-alternative-unlock-list.json
@@ -25,7 +25,8 @@
         {
           "index": 0,
           "name": "establishment_code",
-          "filterType": "text",
+          "filterType": "autocomplete",
+          "referenceType": "establishment",
           "reportFieldType": "string",
           "display": "Establishment Code",
           "description": "@Prompt('Establishment Code','A','Establishment\\Establishment Code',mono,free,,Not_Persistent,,User:3)",
@@ -34,7 +35,8 @@
         {
           "index": 1,
           "name": "wing",
-          "filterType": "text",
+          "filterType": "autocomplete",
+          "referenceType": "wing",
           "reportFieldType": "string",
           "display": "Wing (All for all)",
           "description": "@Prompt('Wing (All for all)','A','Cell\\Level 1 Living Unit LOV',multi,free,,Not_Persistent,,User:4)",
@@ -161,16 +163,18 @@
         {
           "index": 0,
           "name": "establishment_code",
-          "filterType": "text",
+          "filterType": "autocomplete",
+          "referenceType": "establishment",
           "reportFieldType": "string",
-          "display": "Establishment Code",
+          "display": "Establishment",
           "description": "@Prompt('Establishment Code','A','Establishment\\Establishment Code',mono,free,,Not_Persistent,,User:3)",
           "mandatory": "true"
         },
         {
           "index": 1,
           "name": "wing",
-          "filterType": "text",
+          "filterType": "autocomplete",
+          "referenceType": "wing",
           "reportFieldType": "string",
           "display": "Wing (All for all)",
           "description": "@Prompt('Wing (All for all)','A','Cell\\Level 1 Living Unit LOV',multi,free,,Not_Persistent,,User:4)",

--- a/src/main/resources/dev/definitions/prisons/orphanage/ors-alternative-unlock-list.json
+++ b/src/main/resources/dev/definitions/prisons/orphanage/ors-alternative-unlock-list.json
@@ -28,7 +28,7 @@
           "filterType": "autocomplete",
           "referenceType": "establishment",
           "reportFieldType": "string",
-          "display": "Establishment Code",
+          "display": "Establishment",
           "description": "@Prompt('Establishment Code','A','Establishment\\Establishment Code',mono,free,,Not_Persistent,,User:3)",
           "mandatory": "true"
         },

--- a/src/main/resources/dev/definitions/prisons/orphanage/ors-alternative-visits-list.json
+++ b/src/main/resources/dev/definitions/prisons/orphanage/ors-alternative-visits-list.json
@@ -25,7 +25,8 @@
         {
           "index": 0,
           "name": "establishment_code",
-          "filterType": "text",
+          "filterType": "autocomplete",
+          "referenceType": "establishment",
           "reportFieldType": "string",
           "display": "Establishment Code",
           "description": "@Prompt('Establishment Code','A','Establishment\\Establishment Code',mono,free,,Not_Persistent,,User:3)",
@@ -34,7 +35,8 @@
         {
           "index": 1,
           "name": "wing",
-          "filterType": "text",
+          "filterType": "autocomplete",
+          "referenceType": "wing",
           "reportFieldType": "string",
           "display": "Wing (All for all)",
           "description": "@Prompt('Wing (All for all)','A','Cell\\Level 1 Living Unit LOV',multi,free,,Not_Persistent,,User:4)",
@@ -193,7 +195,8 @@
         {
           "index": 0,
           "name": "establishment_code",
-          "filterType": "text",
+          "filterType": "autocomplete",
+          "referenceType": "establishment",
           "reportFieldType": "string",
           "display": "Establishment Code",
           "description": "@Prompt('Establishment Code','A','Establishment\\Establishment Code',mono,free,,Not_Persistent,,User:3)",
@@ -202,7 +205,8 @@
         {
           "index": 1,
           "name": "wing",
-          "filterType": "text",
+          "filterType": "autocomplete",
+          "referenceType": "wing",
           "reportFieldType": "string",
           "display": "Wing (All for all)",
           "description": "@Prompt('Wing (All for all)','A','Cell\\Level 1 Living Unit LOV',multi,free,,Not_Persistent,,User:4)",
@@ -425,7 +429,8 @@
         {
           "index": 0,
           "name": "establishment_code",
-          "filterType": "text",
+          "filterType": "autocomplete",
+          "referenceType": "establishment",
           "reportFieldType": "string",
           "display": "Establishment Code",
           "description": "@Prompt('Establishment Code','A','Establishment\\Establishment Code',mono,free,,Not_Persistent,,User:3)",
@@ -434,7 +439,8 @@
         {
           "index": 1,
           "name": "wing",
-          "filterType": "text",
+          "filterType": "autocomplete",
+          "referenceType": "wing",
           "reportFieldType": "string",
           "display": "Wing (All for all)",
           "description": "@Prompt('Wing (All for all)','A','Cell\\Level 1 Living Unit LOV',multi,free,,Not_Persistent,,User:4)",

--- a/src/main/resources/dev/definitions/prisons/orphanage/ors-alternative-visits-list.json
+++ b/src/main/resources/dev/definitions/prisons/orphanage/ors-alternative-visits-list.json
@@ -28,7 +28,7 @@
           "filterType": "autocomplete",
           "referenceType": "establishment",
           "reportFieldType": "string",
-          "display": "Establishment Code",
+          "display": "Establishment",
           "description": "@Prompt('Establishment Code','A','Establishment\\Establishment Code',mono,free,,Not_Persistent,,User:3)",
           "mandatory": "true"
         },
@@ -198,7 +198,7 @@
           "filterType": "autocomplete",
           "referenceType": "establishment",
           "reportFieldType": "string",
-          "display": "Establishment Code",
+          "display": "Establishment",
           "description": "@Prompt('Establishment Code','A','Establishment\\Establishment Code',mono,free,,Not_Persistent,,User:3)",
           "mandatory": "true"
         },
@@ -432,7 +432,7 @@
           "filterType": "autocomplete",
           "referenceType": "establishment",
           "reportFieldType": "string",
-          "display": "Establishment Code",
+          "display": "Establishment",
           "description": "@Prompt('Establishment Code','A','Establishment\\Establishment Code',mono,free,,Not_Persistent,,User:3)",
           "mandatory": "true"
         },

--- a/src/main/resources/dev/definitions/prisons/orphanage/ors-chaplaincy-alpha-list.json
+++ b/src/main/resources/dev/definitions/prisons/orphanage/ors-chaplaincy-alpha-list.json
@@ -30,7 +30,8 @@
         {
           "index": 0,
           "name": "establishment_code",
-          "filterType": "text",
+          "filterType": "autocomplete",
+          "referenceType": "establishment",
           "reportFieldType": "string",
           "display": "Establishment Code",
           "description": "@Prompt('Establishment Code','A','Establishment\\Establishment Code',mono,free,,Not_Persistent,,User:3)",
@@ -39,7 +40,8 @@
         {
           "index": 1,
           "name": "wing",
-          "filterType": "text",
+          "filterType": "autocomplete",
+          "referenceType": "wing",
           "reportFieldType": "string",
           "display": "Wing (All for all)",
           "description": "@Prompt('Wing (All for all)','A','Cell\\Level 1 Living Unit LOV',multi,free,,Not_Persistent,,User:4)",

--- a/src/main/resources/dev/definitions/prisons/orphanage/ors-chaplaincy-alpha-list.json
+++ b/src/main/resources/dev/definitions/prisons/orphanage/ors-chaplaincy-alpha-list.json
@@ -33,7 +33,7 @@
           "filterType": "autocomplete",
           "referenceType": "establishment",
           "reportFieldType": "string",
-          "display": "Establishment Code",
+          "display": "Establishment",
           "description": "@Prompt('Establishment Code','A','Establishment\\Establishment Code',mono,free,,Not_Persistent,,User:3)",
           "mandatory": "true"
         },

--- a/src/main/resources/dev/definitions/prisons/orphanage/ors-csra-error-report.json
+++ b/src/main/resources/dev/definitions/prisons/orphanage/ors-csra-error-report.json
@@ -27,7 +27,8 @@
         {
           "index": 0,
           "name": "establishment_code",
-          "filterType": "text",
+          "filterType": "autocomplete",
+          "referenceType": "establishment",
           "reportFieldType": "string",
           "display": "Establishment Code",
           "description": "@Prompt('Establishment Code','A','Establishment\\Establishment Code',mono,free,,Not_Persistent,,User:3)",
@@ -89,7 +90,8 @@
         {
           "index": 0,
           "name": "establishment_code",
-          "filterType": "text",
+          "filterType": "autocomplete",
+          "referenceType": "establishment",
           "reportFieldType": "string",
           "display": "Establishment Code",
           "description": "@Prompt('Establishment Code','A','Establishment\\Establishment Code',mono,free,,Not_Persistent,,User:3)",

--- a/src/main/resources/dev/definitions/prisons/orphanage/ors-csra-error-report.json
+++ b/src/main/resources/dev/definitions/prisons/orphanage/ors-csra-error-report.json
@@ -30,7 +30,7 @@
           "filterType": "autocomplete",
           "referenceType": "establishment",
           "reportFieldType": "string",
-          "display": "Establishment Code",
+          "display": "Establishment",
           "description": "@Prompt('Establishment Code','A','Establishment\\Establishment Code',mono,free,,Not_Persistent,,User:3)",
           "mandatory": "true"
         }
@@ -93,7 +93,7 @@
           "filterType": "autocomplete",
           "referenceType": "establishment",
           "reportFieldType": "string",
-          "display": "Establishment Code",
+          "display": "Establishment",
           "description": "@Prompt('Establishment Code','A','Establishment\\Establishment Code',mono,free,,Not_Persistent,,User:3)",
           "mandatory": "true"
         }

--- a/src/main/resources/dev/definitions/prisons/orphanage/ors-daily-discharge-list-condensed-for-pdf.json
+++ b/src/main/resources/dev/definitions/prisons/orphanage/ors-daily-discharge-list-condensed-for-pdf.json
@@ -25,7 +25,8 @@
         {
           "index": 0,
           "name": "establishment_code",
-          "filterType": "text",
+          "filterType": "autocomplete",
+          "referenceType": "establishment",
           "reportFieldType": "string",
           "display": "Establishment Code",
           "description": "@Prompt('Establishment Code','A','Establishment\\Establishment Code',mono,free,,Not_Persistent,,User:3)",
@@ -34,7 +35,8 @@
         {
           "index": 1,
           "name": "wing",
-          "filterType": "text",
+          "filterType": "autocomplete",
+          "referenceType": "wing",
           "reportFieldType": "string",
           "display": "Wing (All for all)",
           "description": "@Prompt('Wing (All for all)','A','Cell\\Location LOV',multi,free,,Not_Persistent,,User:4)",

--- a/src/main/resources/dev/definitions/prisons/orphanage/ors-daily-discharge-list-condensed-for-pdf.json
+++ b/src/main/resources/dev/definitions/prisons/orphanage/ors-daily-discharge-list-condensed-for-pdf.json
@@ -28,7 +28,7 @@
           "filterType": "autocomplete",
           "referenceType": "establishment",
           "reportFieldType": "string",
-          "display": "Establishment Code",
+          "display": "Establishment",
           "description": "@Prompt('Establishment Code','A','Establishment\\Establishment Code',mono,free,,Not_Persistent,,User:3)",
           "mandatory": "true"
         },

--- a/src/main/resources/dev/definitions/prisons/orphanage/ors-daily-discharge-list.json
+++ b/src/main/resources/dev/definitions/prisons/orphanage/ors-daily-discharge-list.json
@@ -25,7 +25,8 @@
         {
           "index": 0,
           "name": "establishment_code",
-          "filterType": "text",
+          "filterType": "autocomplete",
+          "referenceType": "establishment",
           "reportFieldType": "string",
           "display": "Establishment Code",
           "description": "@Prompt('Establishment Code','A','Establishment\\Establishment Code',mono,free,,Not_Persistent,,User:3)",
@@ -34,7 +35,8 @@
         {
           "index": 1,
           "name": "wing",
-          "filterType": "text",
+          "filterType": "autocomplete",
+          "referenceType": "wing",
           "reportFieldType": "string",
           "display": "Wing (All for all)",
           "description": "@Prompt('Wing (All for all)','A','Cell\\Location LOV',multi,free,,Not_Persistent,,User:4)",
@@ -234,7 +236,8 @@
         {
           "index": 0,
           "name": "establishment_code",
-          "filterType": "text",
+          "filterType": "autocomplete",
+          "referenceType": "establishment",
           "reportFieldType": "string",
           "display": "Establishment Code",
           "description": "@Prompt('Establishment Code','A','Establishment\\Establishment Code',mono,free,,Not_Persistent,,User:3)",

--- a/src/main/resources/dev/definitions/prisons/orphanage/ors-daily-discharge-list.json
+++ b/src/main/resources/dev/definitions/prisons/orphanage/ors-daily-discharge-list.json
@@ -28,7 +28,7 @@
           "filterType": "autocomplete",
           "referenceType": "establishment",
           "reportFieldType": "string",
-          "display": "Establishment Code",
+          "display": "Establishment",
           "description": "@Prompt('Establishment Code','A','Establishment\\Establishment Code',mono,free,,Not_Persistent,,User:3)",
           "mandatory": "true"
         },
@@ -239,7 +239,7 @@
           "filterType": "autocomplete",
           "referenceType": "establishment",
           "reportFieldType": "string",
-          "display": "Establishment Code",
+          "display": "Establishment",
           "description": "@Prompt('Establishment Code','A','Establishment\\Establishment Code',mono,free,,Not_Persistent,,User:3)",
           "mandatory": "true"
         }

--- a/src/main/resources/dev/definitions/prisons/orphanage/ors-diary-check-list-report.json
+++ b/src/main/resources/dev/definitions/prisons/orphanage/ors-diary-check-list-report.json
@@ -28,7 +28,7 @@
           "filterType": "autocomplete",
           "referenceType": "establishment",
           "reportFieldType": "string",
-          "display": "Establishment Code",
+          "display": "Establishment",
           "description": "@Prompt('Establishment Code','A','Establishment\\Establishment Code',mono,free,,Not_Persistent,,User:3)",
           "mandatory": "true"
         },
@@ -253,7 +253,7 @@
           "filterType": "autocomplete",
           "referenceType": "establishment",
           "reportFieldType": "string",
-          "display": "Establishment Code",
+          "display": "Establishment",
           "description": "@Prompt('Establishment Code','A','Establishment\\Establishment Code',mono,free,,Not_Persistent,,User:3)",
           "mandatory": "true"
         },

--- a/src/main/resources/dev/definitions/prisons/orphanage/ors-diary-check-list-report.json
+++ b/src/main/resources/dev/definitions/prisons/orphanage/ors-diary-check-list-report.json
@@ -25,7 +25,8 @@
         {
           "index": 0,
           "name": "establishment_code",
-          "filterType": "text",
+          "filterType": "autocomplete",
+          "referenceType": "establishment",
           "reportFieldType": "string",
           "display": "Establishment Code",
           "description": "@Prompt('Establishment Code','A','Establishment\\Establishment Code',mono,free,,Not_Persistent,,User:3)",
@@ -249,7 +250,8 @@
         {
           "index": 0,
           "name": "establishment_code",
-          "filterType": "text",
+          "filterType": "autocomplete",
+          "referenceType": "establishment",
           "reportFieldType": "string",
           "display": "Establishment Code",
           "description": "@Prompt('Establishment Code','A','Establishment\\Establishment Code',mono,free,,Not_Persistent,,User:3)",

--- a/src/main/resources/dev/definitions/prisons/orphanage/ors-discharges-and-receptions-occurred.json
+++ b/src/main/resources/dev/definitions/prisons/orphanage/ors-discharges-and-receptions-occurred.json
@@ -25,7 +25,8 @@
         {
           "index": 0,
           "name": "establishment_code",
-          "filterType": "text",
+          "filterType": "autocomplete",
+          "referenceType": "establishment",
           "reportFieldType": "string",
           "display": "Establishment Code",
           "description": "@Prompt('Establishment Code','A','Establishment\\Establishment Code',mono,free,,Not_Persistent,,User:3)",

--- a/src/main/resources/dev/definitions/prisons/orphanage/ors-discharges-and-receptions-occurred.json
+++ b/src/main/resources/dev/definitions/prisons/orphanage/ors-discharges-and-receptions-occurred.json
@@ -28,7 +28,7 @@
           "filterType": "autocomplete",
           "referenceType": "establishment",
           "reportFieldType": "string",
-          "display": "Establishment Code",
+          "display": "Establishment",
           "description": "@Prompt('Establishment Code','A','Establishment\\Establishment Code',mono,free,,Not_Persistent,,User:3)",
           "mandatory": "true"
         },

--- a/src/main/resources/dev/definitions/prisons/orphanage/ors-fire-roll.json
+++ b/src/main/resources/dev/definitions/prisons/orphanage/ors-fire-roll.json
@@ -30,7 +30,7 @@
           "filterType": "autocomplete",
           "referenceType": "establishment",
           "reportFieldType": "string",
-          "display": "Establishment Code",
+          "display": "Establishment",
           "description": "@Prompt('Establishment Code','A','Establishment\\Establishment Code',mono,free,,Not_Persistent,,User:3)",
           "mandatory": "true"
         },

--- a/src/main/resources/dev/definitions/prisons/orphanage/ors-fire-roll.json
+++ b/src/main/resources/dev/definitions/prisons/orphanage/ors-fire-roll.json
@@ -27,7 +27,8 @@
         {
           "index": 0,
           "name": "establishment_code",
-          "filterType": "text",
+          "filterType": "autocomplete",
+          "referenceType": "establishment",
           "reportFieldType": "string",
           "display": "Establishment Code",
           "description": "@Prompt('Establishment Code','A','Establishment\\Establishment Code',mono,free,,Not_Persistent,,User:3)",
@@ -36,7 +37,8 @@
         {
           "index": 1,
           "name": "wing",
-          "filterType": "text",
+          "filterType": "autocomplete",
+          "referenceType": "wing",
           "reportFieldType": "string",
           "display": "Wing (All for all)",
           "description": "@Prompt('Wing (All for all)','A','Cell\\Level 1 Living Unit LOV',multi,free,,Not_Persistent,,User:4)",

--- a/src/main/resources/dev/definitions/prisons/orphanage/ors-hospital-movements.json
+++ b/src/main/resources/dev/definitions/prisons/orphanage/ors-hospital-movements.json
@@ -25,7 +25,8 @@
         {
           "index": 0,
           "name": "establishment_code",
-          "filterType": "text",
+          "filterType": "autocomplete",
+          "referenceType": "establishment",
           "reportFieldType": "string",
           "display": "Establishment Code",
           "description": "@Prompt('Establishment Code','A','Establishment\\Establishment Code',mono,free,,Not_Persistent,,User:3)",

--- a/src/main/resources/dev/definitions/prisons/orphanage/ors-hospital-movements.json
+++ b/src/main/resources/dev/definitions/prisons/orphanage/ors-hospital-movements.json
@@ -28,7 +28,7 @@
           "filterType": "autocomplete",
           "referenceType": "establishment",
           "reportFieldType": "string",
-          "display": "Establishment Code",
+          "display": "Establishment",
           "description": "@Prompt('Establishment Code','A','Establishment\\Establishment Code',mono,free,,Not_Persistent,,User:3)",
           "mandatory": "true"
         },

--- a/src/main/resources/dev/definitions/prisons/orphanage/ors-iep-error-report.json
+++ b/src/main/resources/dev/definitions/prisons/orphanage/ors-iep-error-report.json
@@ -25,7 +25,8 @@
         {
           "index": 0,
           "name": "establishment_code",
-          "filterType": "text",
+          "filterType": "autocomplete",
+          "referenceType": "establishment",
           "reportFieldType": "string",
           "display": "Establishment Code",
           "description": "@Prompt('Establishment Code','A','Establishment\\Establishment Code',mono,free,,Not_Persistent,,User:3)",

--- a/src/main/resources/dev/definitions/prisons/orphanage/ors-iep-error-report.json
+++ b/src/main/resources/dev/definitions/prisons/orphanage/ors-iep-error-report.json
@@ -28,7 +28,7 @@
           "filterType": "autocomplete",
           "referenceType": "establishment",
           "reportFieldType": "string",
-          "display": "Establishment Code",
+          "display": "Establishment",
           "description": "@Prompt('Establishment Code','A','Establishment\\Establishment Code',mono,free,,Not_Persistent,,User:3)",
           "mandatory": "true"
         }

--- a/src/main/resources/dev/definitions/prisons/orphanage/ors-key-worker-case-notes-update-report.json
+++ b/src/main/resources/dev/definitions/prisons/orphanage/ors-key-worker-case-notes-update-report.json
@@ -30,7 +30,7 @@
           "filterType": "autocomplete",
           "referenceType": "establishment",
           "reportFieldType": "string",
-          "display": "Establishment Code",
+          "display": "Establishment",
           "description": "@Prompt('Establishment Code','A','Establishment\\Establishment Code',mono,free,,Not_Persistent,,User:3)",
           "mandatory": "true"
         },

--- a/src/main/resources/dev/definitions/prisons/orphanage/ors-key-worker-case-notes-update-report.json
+++ b/src/main/resources/dev/definitions/prisons/orphanage/ors-key-worker-case-notes-update-report.json
@@ -27,7 +27,8 @@
         {
           "index": 0,
           "name": "establishment_code",
-          "filterType": "text",
+          "filterType": "autocomplete",
+          "referenceType": "establishment",
           "reportFieldType": "string",
           "display": "Establishment Code",
           "description": "@Prompt('Establishment Code','A','Establishment\\Establishment Code',mono,free,,Not_Persistent,,User:3)",
@@ -36,7 +37,8 @@
         {
           "index": 1,
           "name": "wing",
-          "filterType": "text",
+          "filterType": "autocomplete",
+          "referenceType": "wing",
           "reportFieldType": "string",
           "display": "Wing (All for all)",
           "description": "@Prompt('Wing (All for all)','A','Cell\\Level 1 Living Unit LOV',multi,free,,Not_Persistent,,User:4)",

--- a/src/main/resources/dev/definitions/prisons/orphanage/ors-national-report-of-booked-visits.json
+++ b/src/main/resources/dev/definitions/prisons/orphanage/ors-national-report-of-booked-visits.json
@@ -46,7 +46,7 @@
           "filterType": "autocomplete",
           "referenceType": "establishment",
           "reportFieldType": "string",
-          "display": "Establishment Code",
+          "display": "Establishment",
           "description": "@Prompt('Establishment Code','A','Establishment\\Establishment Code',mono,free,,Not_Persistent,,User:3)",
           "mandatory": "true"
         }

--- a/src/main/resources/dev/definitions/prisons/orphanage/ors-national-report-of-booked-visits.json
+++ b/src/main/resources/dev/definitions/prisons/orphanage/ors-national-report-of-booked-visits.json
@@ -43,7 +43,8 @@
         {
           "index": 2,
           "name": "establishment_code",
-          "filterType": "text",
+          "filterType": "autocomplete",
+          "referenceType": "establishment",
           "reportFieldType": "string",
           "display": "Establishment Code",
           "description": "@Prompt('Establishment Code','A','Establishment\\Establishment Code',mono,free,,Not_Persistent,,User:3)",

--- a/src/main/resources/dev/definitions/prisons/orphanage/ors-oca-report-for-excel-reduced-version.json
+++ b/src/main/resources/dev/definitions/prisons/orphanage/ors-oca-report-for-excel-reduced-version.json
@@ -188,7 +188,7 @@
           "filterType": "autocomplete",
           "referenceType": "establishment",
           "reportFieldType": "string",
-          "display": "Establishment Code",
+          "display": "Establishment",
           "description": "@Prompt('Establishment Code','A','Establishment\\Establishment Code',mono,free,,Not_Persistent,,User:3)",
           "mandatory": "true"
         }

--- a/src/main/resources/dev/definitions/prisons/orphanage/ors-oca-report-for-excel-reduced-version.json
+++ b/src/main/resources/dev/definitions/prisons/orphanage/ors-oca-report-for-excel-reduced-version.json
@@ -185,7 +185,8 @@
         {
           "index": 0,
           "name": "establishment_code",
-          "filterType": "text",
+          "filterType": "autocomplete",
+          "referenceType": "establishment",
           "reportFieldType": "string",
           "display": "Establishment Code",
           "description": "@Prompt('Establishment Code','A','Establishment\\Establishment Code',mono,free,,Not_Persistent,,User:3)",

--- a/src/main/resources/dev/definitions/prisons/orphanage/ors-oca-report-for-excel.json
+++ b/src/main/resources/dev/definitions/prisons/orphanage/ors-oca-report-for-excel.json
@@ -25,7 +25,8 @@
         {
           "index": 0,
           "name": "establishment_code",
-          "filterType": "text",
+          "filterType": "autocomplete",
+          "referenceType": "establishment",
           "reportFieldType": "string",
           "display": "Establishment Code",
           "description": "@Prompt('Establishment Code','A','Establishment/Establishment Code',mono,free,,Not_Persistent,,User:3)",
@@ -399,7 +400,8 @@
         {
           "index": 0,
           "name": "establishment_code",
-          "filterType": "text",
+          "filterType": "autocomplete",
+          "referenceType": "establishment",
           "reportFieldType": "string",
           "display": "Establishment Code",
           "description": "@Prompt('Establishment Code','A','Establishment/Establishment Code',mono,free,,Not_Persistent,,User:3)",
@@ -485,7 +487,8 @@
         {
           "index": 0,
           "name": "establishment_code",
-          "filterType": "text",
+          "filterType": "autocomplete",
+          "referenceType": "establishment",
           "reportFieldType": "string",
           "display": "Establishment Code",
           "description": "@Prompt('Establishment Code','A','Establishment/Establishment Code',mono,free,,Not_Persistent,,User:3)",
@@ -539,7 +542,8 @@
         {
           "index": 0,
           "name": "establishment_code",
-          "filterType": "text",
+          "filterType": "autocomplete",
+          "referenceType": "establishment",
           "reportFieldType": "string",
           "display": "Establishment Code",
           "description": "@Prompt('Establishment Code','A','Establishment/Establishment Code',mono,free,,Not_Persistent,,User:3)",
@@ -585,7 +589,8 @@
         {
           "index": 0,
           "name": "establishment_code",
-          "filterType": "text",
+          "filterType": "autocomplete",
+          "referenceType": "establishment",
           "reportFieldType": "string",
           "display": "Establishment Code",
           "description": "@Prompt('Establishment Code','A','Establishment/Establishment Code',mono,free,,Not_Persistent,,User:3)",
@@ -655,7 +660,8 @@
         {
           "index": 0,
           "name": "establishment_code",
-          "filterType": "text",
+          "filterType": "autocomplete",
+          "referenceType": "establishment",
           "reportFieldType": "string",
           "display": "Establishment Code",
           "description": "@Prompt('Establishment Code','A','Establishment/Establishment Code',mono,free,,Not_Persistent,,User:3)",
@@ -693,7 +699,8 @@
         {
           "index": 0,
           "name": "establishment_code",
-          "filterType": "text",
+          "filterType": "autocomplete",
+          "referenceType": "establishment",
           "reportFieldType": "string",
           "display": "Establishment Code",
           "description": "@Prompt('Establishment Code','A','Establishment/Establishment Code',mono,free,,Not_Persistent,,User:3)",

--- a/src/main/resources/dev/definitions/prisons/orphanage/ors-oca-report-for-excel.json
+++ b/src/main/resources/dev/definitions/prisons/orphanage/ors-oca-report-for-excel.json
@@ -28,7 +28,7 @@
           "filterType": "autocomplete",
           "referenceType": "establishment",
           "reportFieldType": "string",
-          "display": "Establishment Code",
+          "display": "Establishment",
           "description": "@Prompt('Establishment Code','A','Establishment/Establishment Code',mono,free,,Not_Persistent,,User:3)",
           "mandatory": "true"
         }
@@ -403,7 +403,7 @@
           "filterType": "autocomplete",
           "referenceType": "establishment",
           "reportFieldType": "string",
-          "display": "Establishment Code",
+          "display": "Establishment",
           "description": "@Prompt('Establishment Code','A','Establishment/Establishment Code',mono,free,,Not_Persistent,,User:3)",
           "mandatory": "true"
         }
@@ -490,7 +490,7 @@
           "filterType": "autocomplete",
           "referenceType": "establishment",
           "reportFieldType": "string",
-          "display": "Establishment Code",
+          "display": "Establishment",
           "description": "@Prompt('Establishment Code','A','Establishment/Establishment Code',mono,free,,Not_Persistent,,User:3)",
           "mandatory": "true"
         }
@@ -545,7 +545,7 @@
           "filterType": "autocomplete",
           "referenceType": "establishment",
           "reportFieldType": "string",
-          "display": "Establishment Code",
+          "display": "Establishment",
           "description": "@Prompt('Establishment Code','A','Establishment/Establishment Code',mono,free,,Not_Persistent,,User:3)",
           "mandatory": "true"
         }
@@ -592,7 +592,7 @@
           "filterType": "autocomplete",
           "referenceType": "establishment",
           "reportFieldType": "string",
-          "display": "Establishment Code",
+          "display": "Establishment",
           "description": "@Prompt('Establishment Code','A','Establishment/Establishment Code',mono,free,,Not_Persistent,,User:3)",
           "mandatory": "true"
         }
@@ -663,7 +663,7 @@
           "filterType": "autocomplete",
           "referenceType": "establishment",
           "reportFieldType": "string",
-          "display": "Establishment Code",
+          "display": "Establishment",
           "description": "@Prompt('Establishment Code','A','Establishment/Establishment Code',mono,free,,Not_Persistent,,User:3)",
           "mandatory": "true"
         }
@@ -702,7 +702,7 @@
           "filterType": "autocomplete",
           "referenceType": "establishment",
           "reportFieldType": "string",
-          "display": "Establishment Code",
+          "display": "Establishment",
           "description": "@Prompt('Establishment Code','A','Establishment/Establishment Code',mono,free,,Not_Persistent,,User:3)",
           "mandatory": "true"
         }

--- a/src/main/resources/dev/definitions/prisons/orphanage/ors-official-and-social-visit-summary-report.json
+++ b/src/main/resources/dev/definitions/prisons/orphanage/ors-official-and-social-visit-summary-report.json
@@ -43,7 +43,8 @@
         {
           "index": 2,
           "name": "establishment_code",
-          "filterType": "text",
+          "filterType": "autocomplete",
+          "referenceType": "establishment",
           "reportFieldType": "string",
           "display": "Enter value for Visit Establishment Code",
           "description": "@prompt('Enter value for Visit Establishment Code','A','Visits\\Visit Establishment Code',Multi,Free,Not_Persistent,,User:2)",
@@ -139,7 +140,8 @@
         {
           "index": 2,
           "name": "establishment_code",
-          "filterType": "text",
+          "filterType": "autocomplete",
+          "referenceType": "establishment",
           "reportFieldType": "string",
           "display": "Enter value for Visit Establishment Code",
           "description": "@prompt('Enter value for Visit Establishment Code','A','Visits\\Visit Establishment Code',Multi,Free,Not_Persistent,,User:2)",

--- a/src/main/resources/dev/definitions/prisons/orphanage/ors-prisoner-and-visitors-details-report.json
+++ b/src/main/resources/dev/definitions/prisons/orphanage/ors-prisoner-and-visitors-details-report.json
@@ -25,7 +25,8 @@
         {
           "index": 0,
           "name": "establishment_code",
-          "filterType": "text",
+          "filterType": "autocomplete",
+          "referenceType": "establishment",
           "reportFieldType": "string",
           "display": "Establishment Code",
           "description": "@Prompt('Establishment Code','A','Establishment\\Establishment Code',mono,free,,Not_Persistent,,User:3)",

--- a/src/main/resources/dev/definitions/prisons/orphanage/ors-prisoner-and-visitors-details-report.json
+++ b/src/main/resources/dev/definitions/prisons/orphanage/ors-prisoner-and-visitors-details-report.json
@@ -28,7 +28,7 @@
           "filterType": "autocomplete",
           "referenceType": "establishment",
           "reportFieldType": "string",
-          "display": "Establishment Code",
+          "display": "Establishment",
           "description": "@Prompt('Establishment Code','A','Establishment\\Establishment Code',mono,free,,Not_Persistent,,User:3)",
           "mandatory": "true"
         },

--- a/src/main/resources/dev/definitions/prisons/orphanage/ors-prisoner-photographs.json
+++ b/src/main/resources/dev/definitions/prisons/orphanage/ors-prisoner-photographs.json
@@ -25,7 +25,8 @@
         {
           "index": 0,
           "name": "establishment_code",
-          "filterType": "text",
+          "filterType": "autocomplete",
+          "referenceType": "establishment",
           "reportFieldType": "string",
           "display": "Establishment Code",
           "description": "@Prompt('Establishment Code','A','Establishment\\Establishment Code',mono,free,,Not_Persistent,,User:3)",
@@ -34,7 +35,8 @@
         {
           "index": 1,
           "name": "wing",
-          "filterType": "text",
+          "filterType": "autocomplete",
+          "referenceType": "wing",
           "reportFieldType": "string",
           "display": "Wing (All for all)",
           "description": "@Prompt('Wing (All for all)','A','Cell\\Location LOV',multi,free,,Not_Persistent,,User:4)",
@@ -136,7 +138,8 @@
         {
           "index": 0,
           "name": "establishment_code",
-          "filterType": "text",
+          "filterType": "autocomplete",
+          "referenceType": "establishment",
           "reportFieldType": "string",
           "display": "Establishment Code",
           "description": "@Prompt('Establishment Code','A','Establishment\\Establishment Code',mono,free,,Not_Persistent,,User:3)",
@@ -182,7 +185,8 @@
         {
           "index": 0,
           "name": "establishment_code",
-          "filterType": "text",
+          "filterType": "autocomplete",
+          "referenceType": "establishment",
           "reportFieldType": "string",
           "display": "Establishment Code",
           "description": "@Prompt('Establishment Code','A','Establishment\\Establishment Code',mono,free,,Not_Persistent,,User:3)",

--- a/src/main/resources/dev/definitions/prisons/orphanage/ors-prisoner-photographs.json
+++ b/src/main/resources/dev/definitions/prisons/orphanage/ors-prisoner-photographs.json
@@ -28,7 +28,7 @@
           "filterType": "autocomplete",
           "referenceType": "establishment",
           "reportFieldType": "string",
-          "display": "Establishment Code",
+          "display": "Establishment",
           "description": "@Prompt('Establishment Code','A','Establishment\\Establishment Code',mono,free,,Not_Persistent,,User:3)",
           "mandatory": "true"
         },
@@ -141,7 +141,7 @@
           "filterType": "autocomplete",
           "referenceType": "establishment",
           "reportFieldType": "string",
-          "display": "Establishment Code",
+          "display": "Establishment",
           "description": "@Prompt('Establishment Code','A','Establishment\\Establishment Code',mono,free,,Not_Persistent,,User:3)",
           "mandatory": "true"
         }
@@ -188,7 +188,7 @@
           "filterType": "autocomplete",
           "referenceType": "establishment",
           "reportFieldType": "string",
-          "display": "Establishment Code",
+          "display": "Establishment",
           "description": "@Prompt('Establishment Code','A','Establishment\\Establishment Code',mono,free,,Not_Persistent,,User:3)",
           "mandatory": "true"
         }

--- a/src/main/resources/dev/definitions/prisons/orphanage/ors-prisoner-religion.json
+++ b/src/main/resources/dev/definitions/prisons/orphanage/ors-prisoner-religion.json
@@ -27,7 +27,8 @@
         {
           "index": 0,
           "name": "establishment_code",
-          "filterType": "text",
+          "filterType": "autocomplete",
+          "referenceType": "establishment",
           "reportFieldType": "string",
           "display": "Establishment Code",
           "description": "@Prompt('Establishment Code','A','Establishment\\Establishment Code',mono,free,,Not_Persistent,,User:3)",

--- a/src/main/resources/dev/definitions/prisons/orphanage/ors-prisoner-religion.json
+++ b/src/main/resources/dev/definitions/prisons/orphanage/ors-prisoner-religion.json
@@ -30,7 +30,7 @@
           "filterType": "autocomplete",
           "referenceType": "establishment",
           "reportFieldType": "string",
-          "display": "Establishment Code",
+          "display": "Establishment",
           "description": "@Prompt('Establishment Code','A','Establishment\\Establishment Code',mono,free,,Not_Persistent,,User:3)",
           "mandatory": "true"
         }

--- a/src/main/resources/dev/definitions/prisons/orphanage/ors-prisoners-at-court.json
+++ b/src/main/resources/dev/definitions/prisons/orphanage/ors-prisoners-at-court.json
@@ -25,7 +25,8 @@
         {
           "index": 0,
           "name": "establishment_code",
-          "filterType": "text",
+          "filterType": "autocomplete",
+          "referenceType": "establishment",
           "reportFieldType": "string",
           "display": "Establishment Code",
           "description": "@Prompt('Establishment Code','A','Establishment\\Establishment Code',mono,free,,Not_Persistent,,User:3)",

--- a/src/main/resources/dev/definitions/prisons/orphanage/ors-prisoners-at-court.json
+++ b/src/main/resources/dev/definitions/prisons/orphanage/ors-prisoners-at-court.json
@@ -28,7 +28,7 @@
           "filterType": "autocomplete",
           "referenceType": "establishment",
           "reportFieldType": "string",
-          "display": "Establishment Code",
+          "display": "Establishment",
           "description": "@Prompt('Establishment Code','A','Establishment\\Establishment Code',mono,free,,Not_Persistent,,User:3)",
           "mandatory": "true"
         }

--- a/src/main/resources/dev/definitions/prisons/orphanage/ors-prisoners-in-reception-court-or-cswap-more-than-a-day-with-additional-grace-period.json
+++ b/src/main/resources/dev/definitions/prisons/orphanage/ors-prisoners-in-reception-court-or-cswap-more-than-a-day-with-additional-grace-period.json
@@ -25,7 +25,8 @@
         {
           "index": 0,
           "name": "establishment_code",
-          "filterType": "text",
+          "filterType": "autocomplete",
+          "referenceType": "establishment",
           "reportFieldType": "string",
           "display": "Establishment Code",
           "description": "@Prompt('Establishment Code','A','Establishment\\Establishment Code',mono,free,,Not_Persistent,,User:3)",

--- a/src/main/resources/dev/definitions/prisons/orphanage/ors-prisoners-in-reception-court-or-cswap-more-than-a-day-with-additional-grace-period.json
+++ b/src/main/resources/dev/definitions/prisons/orphanage/ors-prisoners-in-reception-court-or-cswap-more-than-a-day-with-additional-grace-period.json
@@ -28,7 +28,7 @@
           "filterType": "autocomplete",
           "referenceType": "establishment",
           "reportFieldType": "string",
-          "display": "Establishment Code",
+          "display": "Establishment",
           "description": "@Prompt('Establishment Code','A','Establishment\\Establishment Code',mono,free,,Not_Persistent,,User:3)",
           "mandatory": "true"
         }

--- a/src/main/resources/dev/definitions/prisons/orphanage/ors-prisoners-missing-ethnicity.json
+++ b/src/main/resources/dev/definitions/prisons/orphanage/ors-prisoners-missing-ethnicity.json
@@ -27,7 +27,8 @@
         {
           "index": 0,
           "name": "establishment_code",
-          "filterType": "text",
+          "filterType": "autocomplete",
+          "referenceType": "establishment",
           "reportFieldType": "string",
           "display": "Establishment Code",
           "description": "@Prompt('Establishment Code','A','Establishment\\Establishment Code',mono,free,,Not_Persistent,,User:3)",

--- a/src/main/resources/dev/definitions/prisons/orphanage/ors-prisoners-missing-ethnicity.json
+++ b/src/main/resources/dev/definitions/prisons/orphanage/ors-prisoners-missing-ethnicity.json
@@ -30,7 +30,7 @@
           "filterType": "autocomplete",
           "referenceType": "establishment",
           "reportFieldType": "string",
-          "display": "Establishment Code",
+          "display": "Establishment",
           "description": "@Prompt('Establishment Code','A','Establishment\\Establishment Code',mono,free,,Not_Persistent,,User:3)",
           "mandatory": "true"
         }

--- a/src/main/resources/dev/definitions/prisons/orphanage/ors-prisoners-missing-nationality.json
+++ b/src/main/resources/dev/definitions/prisons/orphanage/ors-prisoners-missing-nationality.json
@@ -27,7 +27,8 @@
         {
           "index": 0,
           "name": "establishment_code",
-          "filterType": "text",
+          "filterType": "autocomplete",
+          "referenceType": "establishment",
           "reportFieldType": "string",
           "display": "Establishment Code",
           "description": "@Prompt('Establishment Code','A','Establishment\\Establishment Code',mono,free,,Not_Persistent,,User:3)",

--- a/src/main/resources/dev/definitions/prisons/orphanage/ors-prisoners-missing-nationality.json
+++ b/src/main/resources/dev/definitions/prisons/orphanage/ors-prisoners-missing-nationality.json
@@ -30,7 +30,7 @@
           "filterType": "autocomplete",
           "referenceType": "establishment",
           "reportFieldType": "string",
-          "display": "Establishment Code",
+          "display": "Establishment",
           "description": "@Prompt('Establishment Code','A','Establishment\\Establishment Code',mono,free,,Not_Persistent,,User:3)",
           "mandatory": "true"
         }

--- a/src/main/resources/dev/definitions/prisons/orphanage/ors-prisoners-missing-next-of-kin-contact.json
+++ b/src/main/resources/dev/definitions/prisons/orphanage/ors-prisoners-missing-next-of-kin-contact.json
@@ -27,7 +27,8 @@
         {
           "index": 0,
           "name": "establishment_code",
-          "filterType": "text",
+          "filterType": "autocomplete",
+          "referenceType": "establishment",
           "reportFieldType": "string",
           "display": "Establishment Code",
           "description": "@Prompt('Establishment Code','A','Establishment\\Establishment Code',mono,free,,Not_Persistent,,User:3)",

--- a/src/main/resources/dev/definitions/prisons/orphanage/ors-prisoners-missing-next-of-kin-contact.json
+++ b/src/main/resources/dev/definitions/prisons/orphanage/ors-prisoners-missing-next-of-kin-contact.json
@@ -30,7 +30,7 @@
           "filterType": "autocomplete",
           "referenceType": "establishment",
           "reportFieldType": "string",
-          "display": "Establishment Code",
+          "display": "Establishment",
           "description": "@Prompt('Establishment Code','A','Establishment\\Establishment Code',mono,free,,Not_Persistent,,User:3)",
           "mandatory": "true"
         }

--- a/src/main/resources/dev/definitions/prisons/orphanage/ors-prisoners-missing-religion.json
+++ b/src/main/resources/dev/definitions/prisons/orphanage/ors-prisoners-missing-religion.json
@@ -27,7 +27,8 @@
         {
           "index": 0,
           "name": "establishment_code",
-          "filterType": "text",
+          "filterType": "autocomplete",
+          "referenceType": "establishment",
           "reportFieldType": "string",
           "display": "Establishment Code",
           "description": "@Prompt('Establishment Code','A','Establishment\\Establishment Code',mono,free,,Not_Persistent,,User:3)",

--- a/src/main/resources/dev/definitions/prisons/orphanage/ors-prisoners-missing-religion.json
+++ b/src/main/resources/dev/definitions/prisons/orphanage/ors-prisoners-missing-religion.json
@@ -30,7 +30,7 @@
           "filterType": "autocomplete",
           "referenceType": "establishment",
           "reportFieldType": "string",
-          "display": "Establishment Code",
+          "display": "Establishment",
           "description": "@Prompt('Establishment Code','A','Establishment\\Establishment Code',mono,free,,Not_Persistent,,User:3)",
           "mandatory": "true"
         }

--- a/src/main/resources/dev/definitions/prisons/orphanage/ors-prisoners-with-no-visit-history.json
+++ b/src/main/resources/dev/definitions/prisons/orphanage/ors-prisoners-with-no-visit-history.json
@@ -25,7 +25,8 @@
         {
           "index": 0,
           "name": "establishment_code",
-          "filterType": "text",
+          "filterType": "autocomplete",
+          "referenceType": "establishment",
           "reportFieldType": "string",
           "display": "Establishment Code",
           "description": "@Prompt('Establishment Code','A','Establishment\\Establishment Code',mono,free,,Not_Persistent,,User:3)",

--- a/src/main/resources/dev/definitions/prisons/orphanage/ors-prisoners-with-no-visit-history.json
+++ b/src/main/resources/dev/definitions/prisons/orphanage/ors-prisoners-with-no-visit-history.json
@@ -28,7 +28,7 @@
           "filterType": "autocomplete",
           "referenceType": "establishment",
           "reportFieldType": "string",
-          "display": "Establishment Code",
+          "display": "Establishment",
           "description": "@Prompt('Establishment Code','A','Establishment\\Establishment Code',mono,free,,Not_Persistent,,User:3)",
           "mandatory": "true"
         }

--- a/src/main/resources/dev/definitions/prisons/orphanage/ors-prisoners-without-a-social-visit-for-a-date-range.json
+++ b/src/main/resources/dev/definitions/prisons/orphanage/ors-prisoners-without-a-social-visit-for-a-date-range.json
@@ -28,7 +28,7 @@
           "filterType": "autocomplete",
           "referenceType": "establishment",
           "reportFieldType": "string",
-          "display": "Establishment Code",
+          "display": "Establishment",
           "description": "@Prompt('Establishment Code','A','Establishment\\Establishment Code',mono,free,,Not_Persistent,,User:3)",
           "mandatory": "true"
         },
@@ -164,7 +164,7 @@
           "filterType": "autocomplete",
           "referenceType": "establishment",
           "reportFieldType": "string",
-          "display": "Establishment Code",
+          "display": "Establishment",
           "description": "@Prompt('Establishment Code','A','Establishment\\Establishment Code',mono,free,,Not_Persistent,,User:3)",
           "mandatory": "true"
         },
@@ -236,7 +236,7 @@
           "filterType": "autocomplete",
           "referenceType": "establishment",
           "reportFieldType": "string",
-          "display": "Establishment Code",
+          "display": "Establishment",
           "description": "@Prompt('Establishment Code','A','Establishment\\Establishment Code',mono,free,,Not_Persistent,,User:3)",
           "mandatory": "true"
         }
@@ -347,7 +347,7 @@
           "filterType": "autocomplete",
           "referenceType": "establishment",
           "reportFieldType": "string",
-          "display": "Establishment Code",
+          "display": "Establishment",
           "description": "@Prompt('Establishment Code','A','Establishment\\Establishment Code',mono,free,,Not_Persistent,,User:3)",
           "mandatory": "true"
         }
@@ -394,7 +394,7 @@
           "filterType": "autocomplete",
           "referenceType": "establishment",
           "reportFieldType": "string",
-          "display": "Establishment Code",
+          "display": "Establishment",
           "description": "@Prompt('Establishment Code','A','Establishment\\Establishment Code',mono,free,,Not_Persistent,,User:3)",
           "mandatory": "true"
         }
@@ -441,7 +441,7 @@
           "filterType": "autocomplete",
           "referenceType": "establishment",
           "reportFieldType": "string",
-          "display": "Establishment Code",
+          "display": "Establishment",
           "description": "@Prompt('Establishment Code','A','Establishment\\Establishment Code',mono,free,,Not_Persistent,,User:3)",
           "mandatory": "true"
         }
@@ -488,7 +488,7 @@
           "filterType": "autocomplete",
           "referenceType": "establishment",
           "reportFieldType": "string",
-          "display": "Establishment Code",
+          "display": "Establishment",
           "description": "@Prompt('Establishment Code','A','Establishment\\Establishment Code',mono,free,,Not_Persistent,,User:3)",
           "mandatory": "true"
         }

--- a/src/main/resources/dev/definitions/prisons/orphanage/ors-prisoners-without-a-social-visit-for-a-date-range.json
+++ b/src/main/resources/dev/definitions/prisons/orphanage/ors-prisoners-without-a-social-visit-for-a-date-range.json
@@ -25,7 +25,8 @@
         {
           "index": 0,
           "name": "establishment_code",
-          "filterType": "text",
+          "filterType": "autocomplete",
+          "referenceType": "establishment",
           "reportFieldType": "string",
           "display": "Establishment Code",
           "description": "@Prompt('Establishment Code','A','Establishment\\Establishment Code',mono,free,,Not_Persistent,,User:3)",
@@ -160,7 +161,8 @@
         {
           "index": 0,
           "name": "establishment_code",
-          "filterType": "text",
+          "filterType": "autocomplete",
+          "referenceType": "establishment",
           "reportFieldType": "string",
           "display": "Establishment Code",
           "description": "@Prompt('Establishment Code','A','Establishment\\Establishment Code',mono,free,,Not_Persistent,,User:3)",
@@ -231,7 +233,8 @@
         {
           "index": 0,
           "name": "establishment_code",
-          "filterType": "text",
+          "filterType": "autocomplete",
+          "referenceType": "establishment",
           "reportFieldType": "string",
           "display": "Establishment Code",
           "description": "@Prompt('Establishment Code','A','Establishment\\Establishment Code',mono,free,,Not_Persistent,,User:3)",
@@ -341,7 +344,8 @@
         {
           "index": 0,
           "name": "establishment_code",
-          "filterType": "text",
+          "filterType": "autocomplete",
+          "referenceType": "establishment",
           "reportFieldType": "string",
           "display": "Establishment Code",
           "description": "@Prompt('Establishment Code','A','Establishment\\Establishment Code',mono,free,,Not_Persistent,,User:3)",
@@ -387,7 +391,8 @@
         {
           "index": 0,
           "name": "establishment_code",
-          "filterType": "text",
+          "filterType": "autocomplete",
+          "referenceType": "establishment",
           "reportFieldType": "string",
           "display": "Establishment Code",
           "description": "@Prompt('Establishment Code','A','Establishment\\Establishment Code',mono,free,,Not_Persistent,,User:3)",
@@ -433,7 +438,8 @@
         {
           "index": 0,
           "name": "establishment_code",
-          "filterType": "text",
+          "filterType": "autocomplete",
+          "referenceType": "establishment",
           "reportFieldType": "string",
           "display": "Establishment Code",
           "description": "@Prompt('Establishment Code','A','Establishment\\Establishment Code',mono,free,,Not_Persistent,,User:3)",
@@ -479,7 +485,8 @@
         {
           "index": 0,
           "name": "establishment_code",
-          "filterType": "text",
+          "filterType": "autocomplete",
+          "referenceType": "establishment",
           "reportFieldType": "string",
           "display": "Establishment Code",
           "description": "@Prompt('Establishment Code','A','Establishment\\Establishment Code',mono,free,,Not_Persistent,,User:3)",

--- a/src/main/resources/dev/definitions/prisons/orphanage/ors-prisoners-without-visit-history.json
+++ b/src/main/resources/dev/definitions/prisons/orphanage/ors-prisoners-without-visit-history.json
@@ -25,7 +25,8 @@
         {
           "index": 0,
           "name": "establishment_code",
-          "filterType": "text",
+          "filterType": "autocomplete",
+          "referenceType": "establishment",
           "reportFieldType": "string",
           "display": "Establishment Code",
           "description": "@prompt('Establishment Code','A','Visit History\\Establishment Code Where Visit Held',Mono,Free,Not_Persistent,,User:2)",

--- a/src/main/resources/dev/definitions/prisons/orphanage/ors-prisoners-without-visit-history.json
+++ b/src/main/resources/dev/definitions/prisons/orphanage/ors-prisoners-without-visit-history.json
@@ -28,7 +28,7 @@
           "filterType": "autocomplete",
           "referenceType": "establishment",
           "reportFieldType": "string",
-          "display": "Establishment Code",
+          "display": "Establishment",
           "description": "@prompt('Establishment Code','A','Visit History\\Establishment Code Where Visit Held',Mono,Free,Not_Persistent,,User:2)",
           "mandatory": "true"
         }

--- a/src/main/resources/dev/definitions/prisons/orphanage/ors-property-box-allocation-to-active-prisoners.json
+++ b/src/main/resources/dev/definitions/prisons/orphanage/ors-property-box-allocation-to-active-prisoners.json
@@ -25,7 +25,8 @@
         {
           "index": 0,
           "name": "establishment_code",
-          "filterType": "text",
+          "filterType": "autocomplete",
+          "referenceType": "establishment",
           "reportFieldType": "string",
           "display": "Establishment Code",
           "description": "@Prompt('Establishment Code','A','Establishment\\Establishment Code',mono,free,,Not_Persistent,,User:3)",
@@ -127,7 +128,8 @@
         {
           "index": 0,
           "name": "establishment_code",
-          "filterType": "text",
+          "filterType": "autocomplete",
+          "referenceType": "establishment",
           "reportFieldType": "string",
           "display": "Establishment Code",
           "description": "@prompt('Establishment Code','A','Establishment\\Establishment Code',Mono,Free,Not_Persistent,,User:0)",

--- a/src/main/resources/dev/definitions/prisons/orphanage/ors-property-box-allocation-to-active-prisoners.json
+++ b/src/main/resources/dev/definitions/prisons/orphanage/ors-property-box-allocation-to-active-prisoners.json
@@ -28,7 +28,7 @@
           "filterType": "autocomplete",
           "referenceType": "establishment",
           "reportFieldType": "string",
-          "display": "Establishment Code",
+          "display": "Establishment",
           "description": "@Prompt('Establishment Code','A','Establishment\\Establishment Code',mono,free,,Not_Persistent,,User:3)",
           "mandatory": "true"
         }
@@ -131,7 +131,7 @@
           "filterType": "autocomplete",
           "referenceType": "establishment",
           "reportFieldType": "string",
-          "display": "Establishment Code",
+          "display": "Establishment",
           "description": "@prompt('Establishment Code','A','Establishment\\Establishment Code',Mono,Free,Not_Persistent,,User:0)",
           "mandatory": "true"
         }

--- a/src/main/resources/dev/definitions/prisons/orphanage/ors-property-box-error-report.json
+++ b/src/main/resources/dev/definitions/prisons/orphanage/ors-property-box-error-report.json
@@ -25,7 +25,8 @@
         {
           "index": 0,
           "name": "establishment_code",
-          "filterType": "text",
+          "filterType": "autocomplete",
+          "referenceType": "establishment",
           "reportFieldType": "string",
           "display": "Establishment Code",
           "description": "@Prompt('Establishment Code','A','Establishment\\Establishment Code',mono,free,,Not_Persistent,,User:3)",

--- a/src/main/resources/dev/definitions/prisons/orphanage/ors-property-box-error-report.json
+++ b/src/main/resources/dev/definitions/prisons/orphanage/ors-property-box-error-report.json
@@ -28,7 +28,7 @@
           "filterType": "autocomplete",
           "referenceType": "establishment",
           "reportFieldType": "string",
-          "display": "Establishment Code",
+          "display": "Establishment",
           "description": "@Prompt('Establishment Code','A','Establishment\\Establishment Code',mono,free,,Not_Persistent,,User:3)",
           "mandatory": "true"
         }

--- a/src/main/resources/dev/definitions/prisons/orphanage/ors-property-boxes-at-an-establishment.json
+++ b/src/main/resources/dev/definitions/prisons/orphanage/ors-property-boxes-at-an-establishment.json
@@ -25,7 +25,8 @@
         {
           "index": 0,
           "name": "establishment_code",
-          "filterType": "text",
+          "filterType": "autocomplete",
+          "referenceType": "establishment",
           "reportFieldType": "string",
           "display": "Establishment Code",
           "description": "@Prompt('Establishment Code','A','Establishment\\Establishment Code',mono,free,,Not_Persistent,,User:3)",

--- a/src/main/resources/dev/definitions/prisons/orphanage/ors-property-boxes-at-an-establishment.json
+++ b/src/main/resources/dev/definitions/prisons/orphanage/ors-property-boxes-at-an-establishment.json
@@ -28,7 +28,7 @@
           "filterType": "autocomplete",
           "referenceType": "establishment",
           "reportFieldType": "string",
-          "display": "Establishment Code",
+          "display": "Establishment",
           "description": "@Prompt('Establishment Code','A','Establishment\\Establishment Code',mono,free,,Not_Persistent,,User:3)",
           "mandatory": "true"
         }

--- a/src/main/resources/dev/definitions/prisons/orphanage/ors-property-location-history.json
+++ b/src/main/resources/dev/definitions/prisons/orphanage/ors-property-location-history.json
@@ -25,7 +25,8 @@
         {
           "index": 0,
           "name": "establishment_code",
-          "filterType": "text",
+          "filterType": "autocomplete",
+          "referenceType": "establishment",
           "reportFieldType": "string",
           "display": "Establishment Code",
           "description": "@Prompt('Establishment Code','A','Establishment\\Establishment Code',mono,free,,Not_Persistent,,User:3)",

--- a/src/main/resources/dev/definitions/prisons/orphanage/ors-property-location-history.json
+++ b/src/main/resources/dev/definitions/prisons/orphanage/ors-property-location-history.json
@@ -28,7 +28,7 @@
           "filterType": "autocomplete",
           "referenceType": "establishment",
           "reportFieldType": "string",
-          "display": "Establishment Code",
+          "display": "Establishment",
           "description": "@Prompt('Establishment Code','A','Establishment\\Establishment Code',mono,free,,Not_Persistent,,User:3)",
           "mandatory": "true"
         }

--- a/src/main/resources/dev/definitions/prisons/orphanage/ors-resettlement-ete.json
+++ b/src/main/resources/dev/definitions/prisons/orphanage/ors-resettlement-ete.json
@@ -25,7 +25,8 @@
         {
           "index": 0,
           "name": "establishment_code",
-          "filterType": "text",
+          "filterType": "autocomplete",
+          "referenceType": "establishment",
           "reportFieldType": "string",
           "display": "Discharge Location Code",
           "description": "@Prompt('Discharge Location Code','A','Establishment\\Establishment Code',mono,free,,Not_Persistent,,User:0)",

--- a/src/main/resources/dev/definitions/prisons/orphanage/ors-scheduled-court-and-transfer-movements-with-date-range-prompt.json
+++ b/src/main/resources/dev/definitions/prisons/orphanage/ors-scheduled-court-and-transfer-movements-with-date-range-prompt.json
@@ -28,7 +28,7 @@
           "filterType": "autocomplete",
           "referenceType": "establishment",
           "reportFieldType": "string",
-          "display": "Establishment Code",
+          "display": "Establishment",
           "description": "@Prompt('Establishment Code','A','Establishment\\Establishment Code',mono,free,,Not_Persistent,,User:3)",
           "mandatory": "true"
         },
@@ -309,7 +309,7 @@
           "filterType": "autocomplete",
           "referenceType": "establishment",
           "reportFieldType": "string",
-          "display": "Establishment Code",
+          "display": "Establishment",
           "description": "@Prompt('Establishment Code','A','Establishment\\Establishment Code',mono,free,,Not_Persistent,,User:3)",
           "mandatory": "true"
         }
@@ -340,7 +340,7 @@
           "filterType": "autocomplete",
           "referenceType": "establishment",
           "reportFieldType": "string",
-          "display": "Establishment Code",
+          "display": "Establishment",
           "description": "@Prompt('Establishment Code','A','Establishment\\Establishment Code',mono,free,,Not_Persistent,,User:3)",
           "mandatory": "true"
         }

--- a/src/main/resources/dev/definitions/prisons/orphanage/ors-scheduled-court-and-transfer-movements-with-date-range-prompt.json
+++ b/src/main/resources/dev/definitions/prisons/orphanage/ors-scheduled-court-and-transfer-movements-with-date-range-prompt.json
@@ -25,7 +25,8 @@
         {
           "index": 0,
           "name": "establishment_code",
-          "filterType": "text",
+          "filterType": "autocomplete",
+          "referenceType": "establishment",
           "reportFieldType": "string",
           "display": "Establishment Code",
           "description": "@Prompt('Establishment Code','A','Establishment\\Establishment Code',mono,free,,Not_Persistent,,User:3)",
@@ -305,7 +306,8 @@
         {
           "index": 0,
           "name": "establishment_code",
-          "filterType": "text",
+          "filterType": "autocomplete",
+          "referenceType": "establishment",
           "reportFieldType": "string",
           "display": "Establishment Code",
           "description": "@Prompt('Establishment Code','A','Establishment\\Establishment Code',mono,free,,Not_Persistent,,User:3)",
@@ -335,7 +337,8 @@
         {
           "index": 0,
           "name": "establishment_code",
-          "filterType": "text",
+          "filterType": "autocomplete",
+          "referenceType": "establishment",
           "reportFieldType": "string",
           "display": "Establishment Code",
           "description": "@Prompt('Establishment Code','A','Establishment\\Establishment Code',mono,free,,Not_Persistent,,User:3)",

--- a/src/main/resources/dev/definitions/prisons/orphanage/ors-scheduled-court-and-transfer-movements.json
+++ b/src/main/resources/dev/definitions/prisons/orphanage/ors-scheduled-court-and-transfer-movements.json
@@ -25,7 +25,8 @@
         {
           "index": 0,
           "name": "establishment_code",
-          "filterType": "text",
+          "filterType": "autocomplete",
+          "referenceType": "establishment",
           "reportFieldType": "string",
           "display": "Establishment Code",
           "description": "@Prompt('Establishment Code','A','Establishment\\Establishment Code',mono,free,,Not_Persistent,,User:3)",
@@ -297,7 +298,8 @@
         {
           "index": 0,
           "name": "establishment_code",
-          "filterType": "text",
+          "filterType": "autocomplete",
+          "referenceType": "establishment",
           "reportFieldType": "string",
           "display": "Establishment Code",
           "description": "@Prompt('Establishment Code','A','Establishment\\Establishment Code',mono,free,,Not_Persistent,,User:3)",
@@ -327,7 +329,8 @@
         {
           "index": 0,
           "name": "establishment_code",
-          "filterType": "text",
+          "filterType": "autocomplete",
+          "referenceType": "establishment",
           "reportFieldType": "string",
           "display": "Establishment Code",
           "description": "@Prompt('Establishment Code','A','Establishment\\Establishment Code',mono,free,,Not_Persistent,,User:3)",

--- a/src/main/resources/dev/definitions/prisons/orphanage/ors-scheduled-court-and-transfer-movements.json
+++ b/src/main/resources/dev/definitions/prisons/orphanage/ors-scheduled-court-and-transfer-movements.json
@@ -28,7 +28,7 @@
           "filterType": "autocomplete",
           "referenceType": "establishment",
           "reportFieldType": "string",
-          "display": "Establishment Code",
+          "display": "Establishment",
           "description": "@Prompt('Establishment Code','A','Establishment\\Establishment Code',mono,free,,Not_Persistent,,User:3)",
           "mandatory": "true"
         },
@@ -301,7 +301,7 @@
           "filterType": "autocomplete",
           "referenceType": "establishment",
           "reportFieldType": "string",
-          "display": "Establishment Code",
+          "display": "Establishment",
           "description": "@Prompt('Establishment Code','A','Establishment\\Establishment Code',mono,free,,Not_Persistent,,User:3)",
           "mandatory": "true"
         }
@@ -332,7 +332,7 @@
           "filterType": "autocomplete",
           "referenceType": "establishment",
           "reportFieldType": "string",
-          "display": "Establishment Code",
+          "display": "Establishment",
           "description": "@Prompt('Establishment Code','A','Establishment\\Establishment Code',mono,free,,Not_Persistent,,User:3)",
           "mandatory": "true"
         }

--- a/src/main/resources/dev/definitions/prisons/orphanage/ors-scheduled-rotl-movements.json
+++ b/src/main/resources/dev/definitions/prisons/orphanage/ors-scheduled-rotl-movements.json
@@ -25,7 +25,8 @@
         {
           "index": 0,
           "name": "establishment_code",
-          "filterType": "text",
+          "filterType": "autocomplete",
+          "referenceType": "establishment",
           "reportFieldType": "string",
           "display": "Establishment Code",
           "description": "@Prompt('Establishment Code','A','Establishment\\Establishment Code',mono,free,,Not_Persistent,,User:3)",

--- a/src/main/resources/dev/definitions/prisons/orphanage/ors-scheduled-rotl-movements.json
+++ b/src/main/resources/dev/definitions/prisons/orphanage/ors-scheduled-rotl-movements.json
@@ -28,7 +28,7 @@
           "filterType": "autocomplete",
           "referenceType": "establishment",
           "reportFieldType": "string",
-          "display": "Establishment Code",
+          "display": "Establishment",
           "description": "@Prompt('Establishment Code','A','Establishment\\Establishment Code',mono,free,,Not_Persistent,,User:3)",
           "mandatory": "true"
         },

--- a/src/main/resources/dev/definitions/prisons/orphanage/ors-security-movements.json
+++ b/src/main/resources/dev/definitions/prisons/orphanage/ors-security-movements.json
@@ -43,7 +43,8 @@
         {
           "index": 2,
           "name": "establishment_code",
-          "filterType": "text",
+          "filterType": "autocomplete",
+          "referenceType": "establishment",
           "reportFieldType": "string",
           "display": "Establishment Code",
           "description": "@Prompt('Establishment Code','A','Establishment\\Establishment Code',mono,free,,Not_Persistent,,User:3)",
@@ -179,7 +180,8 @@
         {
           "index": 2,
           "name": "establishment_code",
-          "filterType": "text",
+          "filterType": "autocomplete",
+          "referenceType": "establishment",
           "reportFieldType": "string",
           "display": "Establishment Code",
           "description": "@Prompt('Establishment Code','A','Establishment\\Establishment Code',mono,free,,Not_Persistent,,User:3)",

--- a/src/main/resources/dev/definitions/prisons/orphanage/ors-security-movements.json
+++ b/src/main/resources/dev/definitions/prisons/orphanage/ors-security-movements.json
@@ -46,7 +46,7 @@
           "filterType": "autocomplete",
           "referenceType": "establishment",
           "reportFieldType": "string",
-          "display": "Establishment Code",
+          "display": "Establishment",
           "description": "@Prompt('Establishment Code','A','Establishment\\Establishment Code',mono,free,,Not_Persistent,,User:3)",
           "mandatory": "true"
         }
@@ -183,7 +183,7 @@
           "filterType": "autocomplete",
           "referenceType": "establishment",
           "reportFieldType": "string",
-          "display": "Establishment Code",
+          "display": "Establishment",
           "description": "@Prompt('Establishment Code','A','Establishment\\Establishment Code',mono,free,,Not_Persistent,,User:3)",
           "mandatory": "true"
         }

--- a/src/main/resources/dev/definitions/prisons/orphanage/ors-site-visit.json
+++ b/src/main/resources/dev/definitions/prisons/orphanage/ors-site-visit.json
@@ -25,7 +25,8 @@
         {
           "index": 0,
           "name": "establishment_code",
-          "filterType": "text",
+          "filterType": "autocomplete",
+          "referenceType": "establishment",
           "reportFieldType": "string",
           "display": "Establishment Code",
           "description": "@Prompt('Establishment Code','A','Establishment\\Establishment Code',mono,free,,Not_Persistent,,User:3)",

--- a/src/main/resources/dev/definitions/prisons/orphanage/ors-site-visit.json
+++ b/src/main/resources/dev/definitions/prisons/orphanage/ors-site-visit.json
@@ -28,7 +28,7 @@
           "filterType": "autocomplete",
           "referenceType": "establishment",
           "reportFieldType": "string",
-          "display": "Establishment Code",
+          "display": "Establishment",
           "description": "@Prompt('Establishment Code','A','Establishment\\Establishment Code',mono,free,,Not_Persistent,,User:3)",
           "mandatory": "true"
         }

--- a/src/main/resources/dev/definitions/prisons/orphanage/ors-social-visit-history-with-protected-characteristics.json
+++ b/src/main/resources/dev/definitions/prisons/orphanage/ors-social-visit-history-with-protected-characteristics.json
@@ -25,7 +25,8 @@
         {
           "index": 0,
           "name": "establishment_code",
-          "filterType": "text",
+          "filterType": "autocomplete",
+          "referenceType": "establishment",
           "reportFieldType": "string",
           "display": "Establishment Code",
           "description": "@Prompt('Establishment Code','A','Establishment\\Establishment Code',mono,free,,Not_Persistent,,User:3)",
@@ -123,7 +124,8 @@
         {
           "index": 0,
           "name": "establishment_code",
-          "filterType": "text",
+          "filterType": "autocomplete",
+          "referenceType": "establishment",
           "reportFieldType": "string",
           "display": "Establishment Code",
           "description": "@Prompt('Establishment Code','A','Establishment\\Establishment Code',mono,free,,Not_Persistent,,User:3)",
@@ -370,7 +372,8 @@
         {
           "index": 0,
           "name": "establishment_code",
-          "filterType": "text",
+          "filterType": "autocomplete",
+          "referenceType": "establishment",
           "reportFieldType": "string",
           "display": "Establishment Code",
           "description": "@Prompt('Establishment Code','A','Establishment\\Establishment Code',mono,free,,Not_Persistent,,User:3)",
@@ -408,7 +411,8 @@
         {
           "index": 0,
           "name": "establishment_code",
-          "filterType": "text",
+          "filterType": "autocomplete",
+          "referenceType": "establishment",
           "reportFieldType": "string",
           "display": "Establishment Code",
           "description": "@Prompt('Establishment Code','A','Establishment\\Establishment Code',mono,free,,Not_Persistent,,User:3)",
@@ -454,7 +458,8 @@
         {
           "index": 0,
           "name": "establishment_code",
-          "filterType": "text",
+          "filterType": "autocomplete",
+          "referenceType": "establishment",
           "reportFieldType": "string",
           "display": "Establishment Code",
           "description": "@Prompt('Establishment Code','A','Establishment\\Establishment Code',mono,free,,Not_Persistent,,User:3)",
@@ -526,7 +531,8 @@
         {
           "index": 0,
           "name": "establishment_code",
-          "filterType": "text",
+          "filterType": "autocomplete",
+          "referenceType": "establishment",
           "reportFieldType": "string",
           "display": "Establishment Code",
           "description": "@Prompt('Establishment Code','A','Establishment\\Establishment Code',mono,free,,Not_Persistent,,User:3)",
@@ -685,7 +691,8 @@
         {
           "index": 0,
           "name": "establishment_code",
-          "filterType": "text",
+          "filterType": "autocomplete",
+          "referenceType": "establishment",
           "reportFieldType": "string",
           "display": "Establishment Code",
           "description": "@Prompt('Establishment Code','A','Establishment\\Establishment Code',mono,free,,Not_Persistent,,User:3)",

--- a/src/main/resources/dev/definitions/prisons/orphanage/ors-social-visit-history-with-protected-characteristics.json
+++ b/src/main/resources/dev/definitions/prisons/orphanage/ors-social-visit-history-with-protected-characteristics.json
@@ -28,7 +28,7 @@
           "filterType": "autocomplete",
           "referenceType": "establishment",
           "reportFieldType": "string",
-          "display": "Establishment Code",
+          "display": "Establishment",
           "description": "@Prompt('Establishment Code','A','Establishment\\Establishment Code',mono,free,,Not_Persistent,,User:3)",
           "mandatory": "true"
         },
@@ -127,7 +127,7 @@
           "filterType": "autocomplete",
           "referenceType": "establishment",
           "reportFieldType": "string",
-          "display": "Establishment Code",
+          "display": "Establishment",
           "description": "@Prompt('Establishment Code','A','Establishment\\Establishment Code',mono,free,,Not_Persistent,,User:3)",
           "mandatory": "true"
         },
@@ -375,7 +375,7 @@
           "filterType": "autocomplete",
           "referenceType": "establishment",
           "reportFieldType": "string",
-          "display": "Establishment Code",
+          "display": "Establishment",
           "description": "@Prompt('Establishment Code','A','Establishment\\Establishment Code',mono,free,,Not_Persistent,,User:3)",
           "mandatory": "true"
         }
@@ -414,7 +414,7 @@
           "filterType": "autocomplete",
           "referenceType": "establishment",
           "reportFieldType": "string",
-          "display": "Establishment Code",
+          "display": "Establishment",
           "description": "@Prompt('Establishment Code','A','Establishment\\Establishment Code',mono,free,,Not_Persistent,,User:3)",
           "mandatory": "true"
         }
@@ -461,7 +461,7 @@
           "filterType": "autocomplete",
           "referenceType": "establishment",
           "reportFieldType": "string",
-          "display": "Establishment Code",
+          "display": "Establishment",
           "description": "@Prompt('Establishment Code','A','Establishment\\Establishment Code',mono,free,,Not_Persistent,,User:3)",
           "mandatory": "true"
         },
@@ -534,7 +534,7 @@
           "filterType": "autocomplete",
           "referenceType": "establishment",
           "reportFieldType": "string",
-          "display": "Establishment Code",
+          "display": "Establishment",
           "description": "@Prompt('Establishment Code','A','Establishment\\Establishment Code',mono,free,,Not_Persistent,,User:3)",
           "mandatory": "true"
         },
@@ -694,7 +694,7 @@
           "filterType": "autocomplete",
           "referenceType": "establishment",
           "reportFieldType": "string",
-          "display": "Establishment Code",
+          "display": "Establishment",
           "description": "@Prompt('Establishment Code','A','Establishment\\Establishment Code',mono,free,,Not_Persistent,,User:3)",
           "mandatory": "true"
         }

--- a/src/main/resources/dev/definitions/prisons/orphanage/ors-social-visit-statistics.json
+++ b/src/main/resources/dev/definitions/prisons/orphanage/ors-social-visit-statistics.json
@@ -25,7 +25,8 @@
         {
           "index": 0,
           "name": "establishment_code",
-          "filterType": "text",
+          "filterType": "autocomplete",
+          "referenceType": "establishment",
           "reportFieldType": "string",
           "display": "Establishment Code Where Visit Held",
           "description": "@prompt('Enter Establishment Code Where Visit Held','A','Visit History\\Establishment Code Where Visit Held',Multi,Free,Not_Persistent,,User:2)",

--- a/src/main/resources/dev/definitions/prisons/orphanage/ors-summary-of-releases-and-taps.json
+++ b/src/main/resources/dev/definitions/prisons/orphanage/ors-summary-of-releases-and-taps.json
@@ -25,7 +25,8 @@
         {
           "index": 0,
           "name": "establishment_code",
-          "filterType": "text",
+          "filterType": "autocomplete",
+          "referenceType": "establishment",
           "reportFieldType": "string",
           "display": "Establishment Code",
           "description": "@prompt('Establishment Code','A','Establishment\\Establishment Code',Mono,Free,Not_Persistent,,User:0)",
@@ -97,7 +98,8 @@
         {
           "index": 0,
           "name": "establishment_code",
-          "filterType": "text",
+          "filterType": "autocomplete",
+          "referenceType": "establishment",
           "reportFieldType": "string",
           "display": "Establishment Code",
           "description": "@prompt('Establishment Code','A','Establishment\\Establishment Code',Mono,Free,Not_Persistent,,User:0)",

--- a/src/main/resources/dev/definitions/prisons/orphanage/ors-summary-of-releases-and-taps.json
+++ b/src/main/resources/dev/definitions/prisons/orphanage/ors-summary-of-releases-and-taps.json
@@ -28,7 +28,7 @@
           "filterType": "autocomplete",
           "referenceType": "establishment",
           "reportFieldType": "string",
-          "display": "Establishment Code",
+          "display": "Establishment",
           "description": "@prompt('Establishment Code','A','Establishment\\Establishment Code',Mono,Free,Not_Persistent,,User:0)",
           "mandatory": "true"
         },
@@ -101,7 +101,7 @@
           "filterType": "autocomplete",
           "referenceType": "establishment",
           "reportFieldType": "string",
-          "display": "Establishment Code",
+          "display": "Establishment",
           "description": "@prompt('Establishment Code','A','Establishment\\Establishment Code',Mono,Free,Not_Persistent,,User:0)",
           "mandatory": "true"
         },

--- a/src/main/resources/dev/definitions/prisons/orphanage/ors-temporary-absence-and-home-leave-return-dates.json
+++ b/src/main/resources/dev/definitions/prisons/orphanage/ors-temporary-absence-and-home-leave-return-dates.json
@@ -46,7 +46,7 @@
           "filterType": "autocomplete",
           "referenceType": "establishment",
           "reportFieldType": "string",
-          "display": "Establishment Code",
+          "display": "Establishment",
           "description": "@prompt('Establishment Code','A','TAP Return\\Returning To Establishment Code',Mono,Free,Not_Persistent,,User:2)",
           "mandatory": "true"
         }

--- a/src/main/resources/dev/definitions/prisons/orphanage/ors-temporary-absence-and-home-leave-return-dates.json
+++ b/src/main/resources/dev/definitions/prisons/orphanage/ors-temporary-absence-and-home-leave-return-dates.json
@@ -43,7 +43,8 @@
         {
           "index": 2,
           "name": "establishment_code",
-          "filterType": "text",
+          "filterType": "autocomplete",
+          "referenceType": "establishment",
           "reportFieldType": "string",
           "display": "Establishment Code",
           "description": "@prompt('Establishment Code','A','TAP Return\\Returning To Establishment Code',Mono,Free,Not_Persistent,,User:2)",

--- a/src/main/resources/dev/definitions/prisons/orphanage/ors-transfer-holds-report.json
+++ b/src/main/resources/dev/definitions/prisons/orphanage/ors-transfer-holds-report.json
@@ -25,7 +25,8 @@
         {
           "index": 0,
           "name": "establishment_code",
-          "filterType": "text",
+          "filterType": "autocomplete",
+          "referenceType": "establishment",
           "reportFieldType": "string",
           "display": "Establishment Code",
           "description": "@Prompt('Establishment Code','A','Establishment\\Establishment Code',mono,free,,Not_Persistent,,User:3)",
@@ -34,7 +35,8 @@
         {
           "index": 1,
           "name": "wing",
-          "filterType": "text",
+          "filterType": "autocomplete",
+          "referenceType": "wing",
           "reportFieldType": "string",
           "display": "Wing (All for all)",
           "description": "@Prompt('Wing (All for all)','A','Cell\\Location LOV',multi,free,,Not_Persistent,,User:4)",

--- a/src/main/resources/dev/definitions/prisons/orphanage/ors-transfer-holds-report.json
+++ b/src/main/resources/dev/definitions/prisons/orphanage/ors-transfer-holds-report.json
@@ -28,7 +28,7 @@
           "filterType": "autocomplete",
           "referenceType": "establishment",
           "reportFieldType": "string",
-          "display": "Establishment Code",
+          "display": "Establishment",
           "description": "@Prompt('Establishment Code','A','Establishment\\Establishment Code',mono,free,,Not_Persistent,,User:3)",
           "mandatory": "true"
         },

--- a/src/main/resources/dev/definitions/prisons/orphanage/ors-transfers-in-and-out-of-establishments.json
+++ b/src/main/resources/dev/definitions/prisons/orphanage/ors-transfers-in-and-out-of-establishments.json
@@ -28,7 +28,7 @@
           "filterType": "autocomplete",
           "referenceType": "establishment",
           "reportFieldType": "string",
-          "display": "Establishment Code",
+          "display": "Establishment",
           "description": "@prompt('Establishment','A','Establishment\\Establishment',Mono,Free,Not_Persistent,,User:0)",
           "mandatory": "true"
         },

--- a/src/main/resources/dev/definitions/prisons/orphanage/ors-transfers-in-and-out-of-establishments.json
+++ b/src/main/resources/dev/definitions/prisons/orphanage/ors-transfers-in-and-out-of-establishments.json
@@ -25,7 +25,8 @@
         {
           "index": 0,
           "name": "establishment_code",
-          "filterType": "text",
+          "filterType": "autocomplete",
+          "referenceType": "establishment",
           "reportFieldType": "string",
           "display": "Establishment Code",
           "description": "@prompt('Establishment','A','Establishment\\Establishment',Mono,Free,Not_Persistent,,User:0)",

--- a/src/main/resources/dev/definitions/prisons/orphanage/ors-unlock-list.json
+++ b/src/main/resources/dev/definitions/prisons/orphanage/ors-unlock-list.json
@@ -25,7 +25,8 @@
         {
           "index": 0,
           "name": "establishment_code",
-          "filterType": "text",
+          "filterType": "autocomplete",
+          "referenceType": "establishment",
           "reportFieldType": "string",
           "display": "Establishment Code",
           "description": "@Prompt('Establishment Code','A','Establishment\\Establishment Code',mono,free,,Not_Persistent,,User:3)",
@@ -34,7 +35,8 @@
         {
           "index": 1,
           "name": "wing",
-          "filterType": "text",
+          "filterType": "autocomplete",
+          "referenceType": "wing",
           "reportFieldType": "string",
           "display": "Wing (All for all)",
           "description": "@Prompt('Wing (All for all)','A','Cell\\Level 1 Living Unit LOV',multi,free,,Not_Persistent,,User:4)",

--- a/src/main/resources/dev/definitions/prisons/orphanage/ors-unlock-list.json
+++ b/src/main/resources/dev/definitions/prisons/orphanage/ors-unlock-list.json
@@ -28,7 +28,7 @@
           "filterType": "autocomplete",
           "referenceType": "establishment",
           "reportFieldType": "string",
-          "display": "Establishment Code",
+          "display": "Establishment",
           "description": "@Prompt('Establishment Code','A','Establishment\\Establishment Code',mono,free,,Not_Persistent,,User:3)",
           "mandatory": "true"
         },

--- a/src/main/resources/dev/definitions/prisons/orphanage/ors-view-diary-for-a-day.json
+++ b/src/main/resources/dev/definitions/prisons/orphanage/ors-view-diary-for-a-day.json
@@ -25,7 +25,8 @@
         {
           "index": 0,
           "name": "establishment_code",
-          "filterType": "text",
+          "filterType": "autocomplete",
+          "referenceType": "establishment",
           "reportFieldType": "string",
           "display": "Establishment Code",
           "description": "@Prompt('Establishment Code','A','Establishment\\Establishment Code',mono,free,,Not_Persistent,,User:3)",
@@ -34,7 +35,8 @@
         {
           "index": 1,
           "name": "wing",
-          "filterType": "text",
+          "filterType": "autocomplete",
+          "referenceType": "wing",
           "reportFieldType": "string",
           "display": "Wing (All for all)",
           "description": "@Prompt('Wing (All for all)','A','Cell\\Location LOV',multi,free,,Not_Persistent,,User:4)",

--- a/src/main/resources/dev/definitions/prisons/orphanage/ors-view-diary-for-a-day.json
+++ b/src/main/resources/dev/definitions/prisons/orphanage/ors-view-diary-for-a-day.json
@@ -28,7 +28,7 @@
           "filterType": "autocomplete",
           "referenceType": "establishment",
           "reportFieldType": "string",
-          "display": "Establishment Code",
+          "display": "Establishment",
           "description": "@Prompt('Establishment Code','A','Establishment\\Establishment Code',mono,free,,Not_Persistent,,User:3)",
           "mandatory": "true"
         },

--- a/src/main/resources/dev/definitions/prisons/orphanage/ors-visit-history-for-a-prisoner.json
+++ b/src/main/resources/dev/definitions/prisons/orphanage/ors-visit-history-for-a-prisoner.json
@@ -37,7 +37,7 @@
           "filterType": "autocomplete",
           "referenceType": "establishment",
           "reportFieldType": "string",
-          "display": "Establishment Code",
+          "display": "Establishment",
           "description": "@Prompt('Establishment Code','A','Establishment\\Establishment Code',mono,free,,Not_Persistent,,User:3)",
           "mandatory": "true"
         }

--- a/src/main/resources/dev/definitions/prisons/orphanage/ors-visit-history-for-a-prisoner.json
+++ b/src/main/resources/dev/definitions/prisons/orphanage/ors-visit-history-for-a-prisoner.json
@@ -34,7 +34,8 @@
         {
           "index": 1,
           "name": "establishment_code",
-          "filterType": "text",
+          "filterType": "autocomplete",
+          "referenceType": "establishment",
           "reportFieldType": "string",
           "display": "Establishment Code",
           "description": "@Prompt('Establishment Code','A','Establishment\\Establishment Code',mono,free,,Not_Persistent,,User:3)",

--- a/src/main/resources/dev/definitions/prisons/orphanage/ors-visit-history-for-an-establishment.json
+++ b/src/main/resources/dev/definitions/prisons/orphanage/ors-visit-history-for-an-establishment.json
@@ -28,7 +28,7 @@
           "filterType": "autocomplete",
           "referenceType": "establishment",
           "reportFieldType": "string",
-          "display": "Establishment Code",
+          "display": "Establishment",
           "description": "@prompt('Establishment Code','A','Visit History\\Establishment Code Where Visit Held',Mono,Free,Not_Persistent,,User:2)",
           "mandatory": "true"
         },
@@ -205,7 +205,7 @@
           "filterType": "autocomplete",
           "referenceType": "establishment",
           "reportFieldType": "string",
-          "display": "Establishment Code",
+          "display": "Establishment",
           "description": "@prompt('Establishment Code','A','Visit History\\Establishment Code Where Visit Held',Mono,Free,Not_Persistent,,User:2)",
           "mandatory": "true"
         },

--- a/src/main/resources/dev/definitions/prisons/orphanage/ors-visit-history-for-an-establishment.json
+++ b/src/main/resources/dev/definitions/prisons/orphanage/ors-visit-history-for-an-establishment.json
@@ -25,7 +25,8 @@
         {
           "index": 0,
           "name": "establishment_code",
-          "filterType": "text",
+          "filterType": "autocomplete",
+          "referenceType": "establishment",
           "reportFieldType": "string",
           "display": "Establishment Code",
           "description": "@prompt('Establishment Code','A','Visit History\\Establishment Code Where Visit Held',Mono,Free,Not_Persistent,,User:2)",
@@ -201,7 +202,8 @@
         {
           "index": 0,
           "name": "establishment_code",
-          "filterType": "text",
+          "filterType": "autocomplete",
+          "referenceType": "establishment",
           "reportFieldType": "string",
           "display": "Establishment Code",
           "description": "@prompt('Establishment Code','A','Visit History\\Establishment Code Where Visit Held',Mono,Free,Not_Persistent,,User:2)",

--- a/src/main/resources/dev/definitions/prisons/orphanage/ors-visit-orders-remaining.json
+++ b/src/main/resources/dev/definitions/prisons/orphanage/ors-visit-orders-remaining.json
@@ -25,7 +25,8 @@
         {
           "index": 0,
           "name": "establishment_code",
-          "filterType": "text",
+          "filterType": "autocomplete",
+          "referenceType": "establishment",
           "reportFieldType": "string",
           "display": "Establishment Code",
           "description": "@Prompt('Establishment Code','A','Establishment\\Establishment Code',mono,free,,Not_Persistent,,User:3)",

--- a/src/main/resources/dev/definitions/prisons/orphanage/ors-visit-orders-remaining.json
+++ b/src/main/resources/dev/definitions/prisons/orphanage/ors-visit-orders-remaining.json
@@ -28,7 +28,7 @@
           "filterType": "autocomplete",
           "referenceType": "establishment",
           "reportFieldType": "string",
-          "display": "Establishment Code",
+          "display": "Establishment",
           "description": "@Prompt('Establishment Code','A','Establishment\\Establishment Code',mono,free,,Not_Persistent,,User:3)",
           "mandatory": "true"
         }

--- a/src/main/resources/dev/definitions/prisons/orphanage/ors-visits-booked-for-a-date-range-in-the-future.json
+++ b/src/main/resources/dev/definitions/prisons/orphanage/ors-visits-booked-for-a-date-range-in-the-future.json
@@ -25,7 +25,8 @@
         {
           "index": 0,
           "name": "establishment_code",
-          "filterType": "text",
+          "filterType": "autocomplete",
+          "referenceType": "establishment",
           "reportFieldType": "string",
           "display": "Establishment Code",
           "description": "@Prompt('Establishment Code','A','Establishment\\Establishment Code',mono,free,,Not_Persistent,,User:3)",

--- a/src/main/resources/dev/definitions/prisons/orphanage/ors-visits-booked-for-a-date-range-in-the-future.json
+++ b/src/main/resources/dev/definitions/prisons/orphanage/ors-visits-booked-for-a-date-range-in-the-future.json
@@ -28,7 +28,7 @@
           "filterType": "autocomplete",
           "referenceType": "establishment",
           "reportFieldType": "string",
-          "display": "Establishment Code",
+          "display": "Establishment",
           "description": "@Prompt('Establishment Code','A','Establishment\\Establishment Code',mono,free,,Not_Persistent,,User:3)",
           "mandatory": "true"
         },

--- a/src/main/resources/dev/definitions/prisons/orphanage/ors-visits-landing-list.json
+++ b/src/main/resources/dev/definitions/prisons/orphanage/ors-visits-landing-list.json
@@ -25,7 +25,8 @@
         {
           "index": 0,
           "name": "establishment_code",
-          "filterType": "text",
+          "filterType": "autocomplete",
+          "referenceType": "establishment",
           "reportFieldType": "string",
           "display": "Establishment Code",
           "description": "@Prompt('Establishment Code','A','Establishment\\Establishment Code',mono,free,,Not_Persistent,,User:3)",

--- a/src/main/resources/dev/definitions/prisons/orphanage/ors-visits-landing-list.json
+++ b/src/main/resources/dev/definitions/prisons/orphanage/ors-visits-landing-list.json
@@ -28,7 +28,7 @@
           "filterType": "autocomplete",
           "referenceType": "establishment",
           "reportFieldType": "string",
-          "display": "Establishment Code",
+          "display": "Establishment",
           "description": "@Prompt('Establishment Code','A','Establishment\\Establishment Code',mono,free,,Not_Persistent,,User:3)",
           "mandatory": "true"
         },

--- a/src/main/resources/dev/definitions/prisons/orphanage/ors-visits-list.json
+++ b/src/main/resources/dev/definitions/prisons/orphanage/ors-visits-list.json
@@ -25,7 +25,8 @@
         {
           "index": 0,
           "name": "establishment_code",
-          "filterType": "text",
+          "filterType": "autocomplete",
+          "referenceType": "establishment",
           "reportFieldType": "string",
           "display": "Establishment Code",
           "description": "@Prompt('Establishment Code','A','Establishment\\Establishment Code',mono,free,,Not_Persistent,,User:3)",
@@ -34,7 +35,8 @@
         {
           "index": 1,
           "name": "wing",
-          "filterType": "text",
+          "filterType": "autocomplete",
+          "referenceType": "wing",
           "reportFieldType": "string",
           "display": "Wing (All for all)",
           "description": "@Prompt('Wing (All for all)','A','Cell\\Level 1 Living Unit LOV',multi,free,,Not_Persistent,,User:4)",
@@ -233,7 +235,8 @@
         {
           "index": 0,
           "name": "establishment_code",
-          "filterType": "text",
+          "filterType": "autocomplete",
+          "referenceType": "establishment",
           "reportFieldType": "string",
           "display": "Establishment Code",
           "description": "@Prompt('Establishment Code','A','Establishment\\Establishment Code',mono,free,,Not_Persistent,,User:3)",
@@ -242,7 +245,8 @@
         {
           "index": 1,
           "name": "wing",
-          "filterType": "text",
+          "filterType": "autocomplete",
+          "referenceType": "wing",
           "reportFieldType": "string",
           "display": "Wing (All for all)",
           "description": "@Prompt('Wing (All for all)','A','Cell\\Level 1 Living Unit LOV',multi,free,,Not_Persistent,,User:4)",

--- a/src/main/resources/dev/definitions/prisons/orphanage/ors-visits-list.json
+++ b/src/main/resources/dev/definitions/prisons/orphanage/ors-visits-list.json
@@ -28,7 +28,7 @@
           "filterType": "autocomplete",
           "referenceType": "establishment",
           "reportFieldType": "string",
-          "display": "Establishment Code",
+          "display": "Establishment",
           "description": "@Prompt('Establishment Code','A','Establishment\\Establishment Code',mono,free,,Not_Persistent,,User:3)",
           "mandatory": "true"
         },
@@ -238,7 +238,7 @@
           "filterType": "autocomplete",
           "referenceType": "establishment",
           "reportFieldType": "string",
-          "display": "Establishment Code",
+          "display": "Establishment",
           "description": "@Prompt('Establishment Code','A','Establishment\\Establishment Code',mono,free,,Not_Persistent,,User:3)",
           "mandatory": "true"
         },

--- a/src/main/resources/test/definitions/prisons/orphanage/national-social-visit-report.json
+++ b/src/main/resources/test/definitions/prisons/orphanage/national-social-visit-report.json
@@ -43,7 +43,8 @@
         {
           "index": 2,
           "name": "establishment_code",
-          "filterType": "text",
+          "filterType": "autocomplete",
+          "referenceType": "establishment",
           "reportFieldType": "string",
           "display": "Enter value for Visit Establishment Code",
           "description": "@prompt('Enter value for Visit Establishment Code','A','Visits\\Visit Establishment Code',Multi,Free,Not_Persistent,,User:2)",

--- a/src/main/resources/test/definitions/prisons/orphanage/ors-a-and-o-contingency-report.json
+++ b/src/main/resources/test/definitions/prisons/orphanage/ors-a-and-o-contingency-report.json
@@ -25,7 +25,8 @@
         {
           "index": 0,
           "name": "establishment_code",
-          "filterType": "text",
+          "filterType": "autocomplete",
+          "referenceType": "establishment",
           "reportFieldType": "string",
           "display": "Establishment Code",
           "description": "@Prompt('Establishment Code','A','Establishment\\Establishment Code',mono,free,,Not_Persistent,,User:3)",

--- a/src/main/resources/test/definitions/prisons/orphanage/ors-a-and-o-contingency-report.json
+++ b/src/main/resources/test/definitions/prisons/orphanage/ors-a-and-o-contingency-report.json
@@ -28,7 +28,7 @@
           "filterType": "autocomplete",
           "referenceType": "establishment",
           "reportFieldType": "string",
-          "display": "Establishment Code",
+          "display": "Establishment",
           "description": "@Prompt('Establishment Code','A','Establishment\\Establishment Code',mono,free,,Not_Persistent,,User:3)",
           "mandatory": "true"
         }

--- a/src/main/resources/test/definitions/prisons/orphanage/ors-admissions.json
+++ b/src/main/resources/test/definitions/prisons/orphanage/ors-admissions.json
@@ -25,7 +25,8 @@
         {
           "index": 0,
           "name": "establishment_code",
-          "filterType": "text",
+          "filterType": "autocomplete",
+          "referenceType": "establishment",
           "reportFieldType": "string",
           "display": "Establishment Code",
           "description": "@prompt('Establishment Code','A','Establishment\\Establishment Code',Mono,Free,Not_Persistent,,User:0)",
@@ -201,7 +202,8 @@
         {
           "index": 0,
           "name": "establishment_code",
-          "filterType": "text",
+          "filterType": "autocomplete",
+          "referenceType": "establishment",
           "reportFieldType": "string",
           "display": "Establishment Code",
           "description": "@prompt('Establishment Code','A','Establishment\\Establishment Code',Mono,Free,Not_Persistent,,User:0)",
@@ -257,7 +259,8 @@
         {
           "index": 0,
           "name": "establishment_code",
-          "filterType": "text",
+          "filterType": "autocomplete",
+          "referenceType": "establishment",
           "reportFieldType": "string",
           "display": "Establishment Code",
           "description": "@prompt('Establishment Code','A','Establishment\\Establishment Code',Mono,Free,Not_Persistent,,User:0)",

--- a/src/main/resources/test/definitions/prisons/orphanage/ors-admissions.json
+++ b/src/main/resources/test/definitions/prisons/orphanage/ors-admissions.json
@@ -28,7 +28,7 @@
           "filterType": "autocomplete",
           "referenceType": "establishment",
           "reportFieldType": "string",
-          "display": "Establishment Code",
+          "display": "Establishment",
           "description": "@prompt('Establishment Code','A','Establishment\\Establishment Code',Mono,Free,Not_Persistent,,User:0)",
           "mandatory": "true"
         },
@@ -205,7 +205,7 @@
           "filterType": "autocomplete",
           "referenceType": "establishment",
           "reportFieldType": "string",
-          "display": "Establishment Code",
+          "display": "Establishment",
           "description": "@prompt('Establishment Code','A','Establishment\\Establishment Code',Mono,Free,Not_Persistent,,User:0)",
           "mandatory": "true"
         },
@@ -262,7 +262,7 @@
           "filterType": "autocomplete",
           "referenceType": "establishment",
           "reportFieldType": "string",
-          "display": "Establishment Code",
+          "display": "Establishment",
           "description": "@prompt('Establishment Code','A','Establishment\\Establishment Code',Mono,Free,Not_Persistent,,User:0)",
           "mandatory": "true"
         },

--- a/src/main/resources/test/definitions/prisons/orphanage/ors-alerts-report.json
+++ b/src/main/resources/test/definitions/prisons/orphanage/ors-alerts-report.json
@@ -28,7 +28,8 @@
         {
           "index": 0,
           "name": "establishment_code",
-          "filterType": "text",
+          "filterType": "autocomplete",
+          "referenceType": "establishment",
           "reportFieldType": "string",
           "display": "Establishment Code",
           "description": "",
@@ -37,7 +38,8 @@
         {
           "index": 1,
           "name": "wing",
-          "filterType": "text",
+          "filterType": "autocomplete",
+          "referenceType": "wing",
           "reportFieldType": "string",
           "display": "Wing (All for all)",
           "description": "",

--- a/src/main/resources/test/definitions/prisons/orphanage/ors-alerts-report.json
+++ b/src/main/resources/test/definitions/prisons/orphanage/ors-alerts-report.json
@@ -31,7 +31,7 @@
           "filterType": "autocomplete",
           "referenceType": "establishment",
           "reportFieldType": "string",
-          "display": "Establishment Code",
+          "display": "Establishment",
           "description": "",
           "mandatory": "true"
         },

--- a/src/main/resources/test/definitions/prisons/orphanage/ors-alternative-unlock-list.json
+++ b/src/main/resources/test/definitions/prisons/orphanage/ors-alternative-unlock-list.json
@@ -25,7 +25,8 @@
         {
           "index": 0,
           "name": "establishment_code",
-          "filterType": "text",
+          "filterType": "autocomplete",
+          "referenceType": "establishment",
           "reportFieldType": "string",
           "display": "Establishment Code",
           "description": "@Prompt('Establishment Code','A','Establishment\\Establishment Code',mono,free,,Not_Persistent,,User:3)",
@@ -34,7 +35,8 @@
         {
           "index": 1,
           "name": "wing",
-          "filterType": "text",
+          "filterType": "autocomplete",
+          "referenceType": "wing",
           "reportFieldType": "string",
           "display": "Wing (All for all)",
           "description": "@Prompt('Wing (All for all)','A','Cell\\Level 1 Living Unit LOV',multi,free,,Not_Persistent,,User:4)",
@@ -161,7 +163,8 @@
         {
           "index": 0,
           "name": "establishment_code",
-          "filterType": "text",
+          "filterType": "autocomplete",
+          "referenceType": "establishment",
           "reportFieldType": "string",
           "display": "Establishment Code",
           "description": "@Prompt('Establishment Code','A','Establishment\\Establishment Code',mono,free,,Not_Persistent,,User:3)",
@@ -170,7 +173,8 @@
         {
           "index": 1,
           "name": "wing",
-          "filterType": "text",
+          "filterType": "autocomplete",
+          "referenceType": "wing",
           "reportFieldType": "string",
           "display": "Wing (All for all)",
           "description": "@Prompt('Wing (All for all)','A','Cell\\Level 1 Living Unit LOV',multi,free,,Not_Persistent,,User:4)",

--- a/src/main/resources/test/definitions/prisons/orphanage/ors-alternative-unlock-list.json
+++ b/src/main/resources/test/definitions/prisons/orphanage/ors-alternative-unlock-list.json
@@ -28,7 +28,7 @@
           "filterType": "autocomplete",
           "referenceType": "establishment",
           "reportFieldType": "string",
-          "display": "Establishment Code",
+          "display": "Establishment",
           "description": "@Prompt('Establishment Code','A','Establishment\\Establishment Code',mono,free,,Not_Persistent,,User:3)",
           "mandatory": "true"
         },
@@ -166,7 +166,7 @@
           "filterType": "autocomplete",
           "referenceType": "establishment",
           "reportFieldType": "string",
-          "display": "Establishment Code",
+          "display": "Establishment",
           "description": "@Prompt('Establishment Code','A','Establishment\\Establishment Code',mono,free,,Not_Persistent,,User:3)",
           "mandatory": "true"
         },

--- a/src/main/resources/test/definitions/prisons/orphanage/ors-alternative-visits-list.json
+++ b/src/main/resources/test/definitions/prisons/orphanage/ors-alternative-visits-list.json
@@ -25,7 +25,8 @@
         {
           "index": 0,
           "name": "establishment_code",
-          "filterType": "text",
+          "filterType": "autocomplete",
+          "referenceType": "establishment",
           "reportFieldType": "string",
           "display": "Establishment Code",
           "description": "@Prompt('Establishment Code','A','Establishment\\Establishment Code',mono,free,,Not_Persistent,,User:3)",
@@ -34,7 +35,8 @@
         {
           "index": 1,
           "name": "wing",
-          "filterType": "text",
+          "filterType": "autocomplete",
+          "referenceType": "wing",
           "reportFieldType": "string",
           "display": "Wing (All for all)",
           "description": "@Prompt('Wing (All for all)','A','Cell\\Level 1 Living Unit LOV',multi,free,,Not_Persistent,,User:4)",
@@ -193,7 +195,8 @@
         {
           "index": 0,
           "name": "establishment_code",
-          "filterType": "text",
+          "filterType": "autocomplete",
+          "referenceType": "establishment",
           "reportFieldType": "string",
           "display": "Establishment Code",
           "description": "@Prompt('Establishment Code','A','Establishment\\Establishment Code',mono,free,,Not_Persistent,,User:3)",
@@ -202,7 +205,8 @@
         {
           "index": 1,
           "name": "wing",
-          "filterType": "text",
+          "filterType": "autocomplete",
+          "referenceType": "wing",
           "reportFieldType": "string",
           "display": "Wing (All for all)",
           "description": "@Prompt('Wing (All for all)','A','Cell\\Level 1 Living Unit LOV',multi,free,,Not_Persistent,,User:4)",
@@ -425,7 +429,8 @@
         {
           "index": 0,
           "name": "establishment_code",
-          "filterType": "text",
+          "filterType": "autocomplete",
+          "referenceType": "establishment",
           "reportFieldType": "string",
           "display": "Establishment Code",
           "description": "@Prompt('Establishment Code','A','Establishment\\Establishment Code',mono,free,,Not_Persistent,,User:3)",
@@ -434,7 +439,8 @@
         {
           "index": 1,
           "name": "wing",
-          "filterType": "text",
+          "filterType": "autocomplete",
+          "referenceType": "wing",
           "reportFieldType": "string",
           "display": "Wing (All for all)",
           "description": "@Prompt('Wing (All for all)','A','Cell\\Level 1 Living Unit LOV',multi,free,,Not_Persistent,,User:4)",

--- a/src/main/resources/test/definitions/prisons/orphanage/ors-alternative-visits-list.json
+++ b/src/main/resources/test/definitions/prisons/orphanage/ors-alternative-visits-list.json
@@ -28,7 +28,7 @@
           "filterType": "autocomplete",
           "referenceType": "establishment",
           "reportFieldType": "string",
-          "display": "Establishment Code",
+          "display": "Establishment",
           "description": "@Prompt('Establishment Code','A','Establishment\\Establishment Code',mono,free,,Not_Persistent,,User:3)",
           "mandatory": "true"
         },
@@ -198,7 +198,7 @@
           "filterType": "autocomplete",
           "referenceType": "establishment",
           "reportFieldType": "string",
-          "display": "Establishment Code",
+          "display": "Establishment",
           "description": "@Prompt('Establishment Code','A','Establishment\\Establishment Code',mono,free,,Not_Persistent,,User:3)",
           "mandatory": "true"
         },
@@ -432,7 +432,7 @@
           "filterType": "autocomplete",
           "referenceType": "establishment",
           "reportFieldType": "string",
-          "display": "Establishment Code",
+          "display": "Establishment",
           "description": "@Prompt('Establishment Code','A','Establishment\\Establishment Code',mono,free,,Not_Persistent,,User:3)",
           "mandatory": "true"
         },

--- a/src/main/resources/test/definitions/prisons/orphanage/ors-chaplaincy-alpha-list.json
+++ b/src/main/resources/test/definitions/prisons/orphanage/ors-chaplaincy-alpha-list.json
@@ -30,7 +30,8 @@
         {
           "index": 0,
           "name": "establishment_code",
-          "filterType": "text",
+          "filterType": "autocomplete",
+          "referenceType": "establishment",
           "reportFieldType": "string",
           "display": "Establishment Code",
           "description": "@Prompt('Establishment Code','A','Establishment\\Establishment Code',mono,free,,Not_Persistent,,User:3)",
@@ -39,7 +40,8 @@
         {
           "index": 1,
           "name": "wing",
-          "filterType": "text",
+          "filterType": "autocomplete",
+          "referenceType": "wing",
           "reportFieldType": "string",
           "display": "Wing (All for all)",
           "description": "@Prompt('Wing (All for all)','A','Cell\\Level 1 Living Unit LOV',multi,free,,Not_Persistent,,User:4)",

--- a/src/main/resources/test/definitions/prisons/orphanage/ors-chaplaincy-alpha-list.json
+++ b/src/main/resources/test/definitions/prisons/orphanage/ors-chaplaincy-alpha-list.json
@@ -33,7 +33,7 @@
           "filterType": "autocomplete",
           "referenceType": "establishment",
           "reportFieldType": "string",
-          "display": "Establishment Code",
+          "display": "Establishment",
           "description": "@Prompt('Establishment Code','A','Establishment\\Establishment Code',mono,free,,Not_Persistent,,User:3)",
           "mandatory": "true"
         },

--- a/src/main/resources/test/definitions/prisons/orphanage/ors-csra-error-report.json
+++ b/src/main/resources/test/definitions/prisons/orphanage/ors-csra-error-report.json
@@ -27,7 +27,8 @@
         {
           "index": 0,
           "name": "establishment_code",
-          "filterType": "text",
+          "filterType": "autocomplete",
+          "referenceType": "establishment",
           "reportFieldType": "string",
           "display": "Establishment Code",
           "description": "@Prompt('Establishment Code','A','Establishment\\Establishment Code',mono,free,,Not_Persistent,,User:3)",
@@ -89,7 +90,8 @@
         {
           "index": 0,
           "name": "establishment_code",
-          "filterType": "text",
+          "filterType": "autocomplete",
+          "referenceType": "establishment",
           "reportFieldType": "string",
           "display": "Establishment Code",
           "description": "@Prompt('Establishment Code','A','Establishment\\Establishment Code',mono,free,,Not_Persistent,,User:3)",

--- a/src/main/resources/test/definitions/prisons/orphanage/ors-csra-error-report.json
+++ b/src/main/resources/test/definitions/prisons/orphanage/ors-csra-error-report.json
@@ -30,7 +30,7 @@
           "filterType": "autocomplete",
           "referenceType": "establishment",
           "reportFieldType": "string",
-          "display": "Establishment Code",
+          "display": "Establishment",
           "description": "@Prompt('Establishment Code','A','Establishment\\Establishment Code',mono,free,,Not_Persistent,,User:3)",
           "mandatory": "true"
         }
@@ -93,7 +93,7 @@
           "filterType": "autocomplete",
           "referenceType": "establishment",
           "reportFieldType": "string",
-          "display": "Establishment Code",
+          "display": "Establishment",
           "description": "@Prompt('Establishment Code','A','Establishment\\Establishment Code',mono,free,,Not_Persistent,,User:3)",
           "mandatory": "true"
         }

--- a/src/main/resources/test/definitions/prisons/orphanage/ors-daily-discharge-list-condensed-for-pdf.json
+++ b/src/main/resources/test/definitions/prisons/orphanage/ors-daily-discharge-list-condensed-for-pdf.json
@@ -25,7 +25,8 @@
         {
           "index": 0,
           "name": "establishment_code",
-          "filterType": "text",
+          "filterType": "autocomplete",
+          "referenceType": "establishment",
           "reportFieldType": "string",
           "display": "Establishment Code",
           "description": "@Prompt('Establishment Code','A','Establishment\\Establishment Code',mono,free,,Not_Persistent,,User:3)",
@@ -34,7 +35,8 @@
         {
           "index": 1,
           "name": "wing",
-          "filterType": "text",
+          "filterType": "autocomplete",
+          "referenceType": "wing",
           "reportFieldType": "string",
           "display": "Wing (All for all)",
           "description": "@Prompt('Wing (All for all)','A','Cell\\Location LOV',multi,free,,Not_Persistent,,User:4)",

--- a/src/main/resources/test/definitions/prisons/orphanage/ors-daily-discharge-list-condensed-for-pdf.json
+++ b/src/main/resources/test/definitions/prisons/orphanage/ors-daily-discharge-list-condensed-for-pdf.json
@@ -28,7 +28,7 @@
           "filterType": "autocomplete",
           "referenceType": "establishment",
           "reportFieldType": "string",
-          "display": "Establishment Code",
+          "display": "Establishment",
           "description": "@Prompt('Establishment Code','A','Establishment\\Establishment Code',mono,free,,Not_Persistent,,User:3)",
           "mandatory": "true"
         },

--- a/src/main/resources/test/definitions/prisons/orphanage/ors-daily-discharge-list.json
+++ b/src/main/resources/test/definitions/prisons/orphanage/ors-daily-discharge-list.json
@@ -25,7 +25,8 @@
         {
           "index": 0,
           "name": "establishment_code",
-          "filterType": "text",
+          "filterType": "autocomplete",
+          "referenceType": "establishment",
           "reportFieldType": "string",
           "display": "Establishment Code",
           "description": "@Prompt('Establishment Code','A','Establishment\\Establishment Code',mono,free,,Not_Persistent,,User:3)",
@@ -34,7 +35,8 @@
         {
           "index": 1,
           "name": "wing",
-          "filterType": "text",
+          "filterType": "autocomplete",
+          "referenceType": "wing",
           "reportFieldType": "string",
           "display": "Wing (All for all)",
           "description": "@Prompt('Wing (All for all)','A','Cell\\Location LOV',multi,free,,Not_Persistent,,User:4)",
@@ -234,7 +236,8 @@
         {
           "index": 0,
           "name": "establishment_code",
-          "filterType": "text",
+          "filterType": "autocomplete",
+          "referenceType": "establishment",
           "reportFieldType": "string",
           "display": "Establishment Code",
           "description": "@Prompt('Establishment Code','A','Establishment\\Establishment Code',mono,free,,Not_Persistent,,User:3)",

--- a/src/main/resources/test/definitions/prisons/orphanage/ors-daily-discharge-list.json
+++ b/src/main/resources/test/definitions/prisons/orphanage/ors-daily-discharge-list.json
@@ -28,7 +28,7 @@
           "filterType": "autocomplete",
           "referenceType": "establishment",
           "reportFieldType": "string",
-          "display": "Establishment Code",
+          "display": "Establishment",
           "description": "@Prompt('Establishment Code','A','Establishment\\Establishment Code',mono,free,,Not_Persistent,,User:3)",
           "mandatory": "true"
         },
@@ -239,7 +239,7 @@
           "filterType": "autocomplete",
           "referenceType": "establishment",
           "reportFieldType": "string",
-          "display": "Establishment Code",
+          "display": "Establishment",
           "description": "@Prompt('Establishment Code','A','Establishment\\Establishment Code',mono,free,,Not_Persistent,,User:3)",
           "mandatory": "true"
         }

--- a/src/main/resources/test/definitions/prisons/orphanage/ors-diary-check-list-report.json
+++ b/src/main/resources/test/definitions/prisons/orphanage/ors-diary-check-list-report.json
@@ -28,7 +28,7 @@
           "filterType": "autocomplete",
           "referenceType": "establishment",
           "reportFieldType": "string",
-          "display": "Establishment Code",
+          "display": "Establishment",
           "description": "@Prompt('Establishment Code','A','Establishment\\Establishment Code',mono,free,,Not_Persistent,,User:3)",
           "mandatory": "true"
         },
@@ -253,7 +253,7 @@
           "filterType": "autocomplete",
           "referenceType": "establishment",
           "reportFieldType": "string",
-          "display": "Establishment Code",
+          "display": "Establishment",
           "description": "@Prompt('Establishment Code','A','Establishment\\Establishment Code',mono,free,,Not_Persistent,,User:3)",
           "mandatory": "true"
         },

--- a/src/main/resources/test/definitions/prisons/orphanage/ors-diary-check-list-report.json
+++ b/src/main/resources/test/definitions/prisons/orphanage/ors-diary-check-list-report.json
@@ -25,7 +25,8 @@
         {
           "index": 0,
           "name": "establishment_code",
-          "filterType": "text",
+          "filterType": "autocomplete",
+          "referenceType": "establishment",
           "reportFieldType": "string",
           "display": "Establishment Code",
           "description": "@Prompt('Establishment Code','A','Establishment\\Establishment Code',mono,free,,Not_Persistent,,User:3)",
@@ -249,7 +250,8 @@
         {
           "index": 0,
           "name": "establishment_code",
-          "filterType": "text",
+          "filterType": "autocomplete",
+          "referenceType": "establishment",
           "reportFieldType": "string",
           "display": "Establishment Code",
           "description": "@Prompt('Establishment Code','A','Establishment\\Establishment Code',mono,free,,Not_Persistent,,User:3)",

--- a/src/main/resources/test/definitions/prisons/orphanage/ors-discharges-and-receptions-occurred.json
+++ b/src/main/resources/test/definitions/prisons/orphanage/ors-discharges-and-receptions-occurred.json
@@ -25,7 +25,8 @@
         {
           "index": 0,
           "name": "establishment_code",
-          "filterType": "text",
+          "filterType": "autocomplete",
+          "referenceType": "establishment",
           "reportFieldType": "string",
           "display": "Establishment Code",
           "description": "@Prompt('Establishment Code','A','Establishment\\Establishment Code',mono,free,,Not_Persistent,,User:3)",

--- a/src/main/resources/test/definitions/prisons/orphanage/ors-discharges-and-receptions-occurred.json
+++ b/src/main/resources/test/definitions/prisons/orphanage/ors-discharges-and-receptions-occurred.json
@@ -28,7 +28,7 @@
           "filterType": "autocomplete",
           "referenceType": "establishment",
           "reportFieldType": "string",
-          "display": "Establishment Code",
+          "display": "Establishment",
           "description": "@Prompt('Establishment Code','A','Establishment\\Establishment Code',mono,free,,Not_Persistent,,User:3)",
           "mandatory": "true"
         },

--- a/src/main/resources/test/definitions/prisons/orphanage/ors-fire-roll.json
+++ b/src/main/resources/test/definitions/prisons/orphanage/ors-fire-roll.json
@@ -30,7 +30,7 @@
           "filterType": "autocomplete",
           "referenceType": "establishment",
           "reportFieldType": "string",
-          "display": "Establishment Code",
+          "display": "Establishment",
           "description": "@Prompt('Establishment Code','A','Establishment\\Establishment Code',mono,free,,Not_Persistent,,User:3)",
           "mandatory": "true"
         },

--- a/src/main/resources/test/definitions/prisons/orphanage/ors-fire-roll.json
+++ b/src/main/resources/test/definitions/prisons/orphanage/ors-fire-roll.json
@@ -27,7 +27,8 @@
         {
           "index": 0,
           "name": "establishment_code",
-          "filterType": "text",
+          "filterType": "autocomplete",
+          "referenceType": "establishment",
           "reportFieldType": "string",
           "display": "Establishment Code",
           "description": "@Prompt('Establishment Code','A','Establishment\\Establishment Code',mono,free,,Not_Persistent,,User:3)",
@@ -36,7 +37,8 @@
         {
           "index": 1,
           "name": "wing",
-          "filterType": "text",
+          "filterType": "autocomplete",
+          "referenceType": "wing",
           "reportFieldType": "string",
           "display": "Wing (All for all)",
           "description": "@Prompt('Wing (All for all)','A','Cell\\Level 1 Living Unit LOV',multi,free,,Not_Persistent,,User:4)",

--- a/src/main/resources/test/definitions/prisons/orphanage/ors-hospital-movements.json
+++ b/src/main/resources/test/definitions/prisons/orphanage/ors-hospital-movements.json
@@ -25,7 +25,8 @@
         {
           "index": 0,
           "name": "establishment_code",
-          "filterType": "text",
+          "filterType": "autocomplete",
+          "referenceType": "establishment",
           "reportFieldType": "string",
           "display": "Establishment Code",
           "description": "@Prompt('Establishment Code','A','Establishment\\Establishment Code',mono,free,,Not_Persistent,,User:3)",

--- a/src/main/resources/test/definitions/prisons/orphanage/ors-hospital-movements.json
+++ b/src/main/resources/test/definitions/prisons/orphanage/ors-hospital-movements.json
@@ -28,7 +28,7 @@
           "filterType": "autocomplete",
           "referenceType": "establishment",
           "reportFieldType": "string",
-          "display": "Establishment Code",
+          "display": "Establishment",
           "description": "@Prompt('Establishment Code','A','Establishment\\Establishment Code',mono,free,,Not_Persistent,,User:3)",
           "mandatory": "true"
         },

--- a/src/main/resources/test/definitions/prisons/orphanage/ors-iep-error-report.json
+++ b/src/main/resources/test/definitions/prisons/orphanage/ors-iep-error-report.json
@@ -25,7 +25,8 @@
         {
           "index": 0,
           "name": "establishment_code",
-          "filterType": "text",
+          "filterType": "autocomplete",
+          "referenceType": "establishment",
           "reportFieldType": "string",
           "display": "Establishment Code",
           "description": "@Prompt('Establishment Code','A','Establishment\\Establishment Code',mono,free,,Not_Persistent,,User:3)",

--- a/src/main/resources/test/definitions/prisons/orphanage/ors-iep-error-report.json
+++ b/src/main/resources/test/definitions/prisons/orphanage/ors-iep-error-report.json
@@ -28,7 +28,7 @@
           "filterType": "autocomplete",
           "referenceType": "establishment",
           "reportFieldType": "string",
-          "display": "Establishment Code",
+          "display": "Establishment",
           "description": "@Prompt('Establishment Code','A','Establishment\\Establishment Code',mono,free,,Not_Persistent,,User:3)",
           "mandatory": "true"
         }

--- a/src/main/resources/test/definitions/prisons/orphanage/ors-key-worker-case-notes-update-report.json
+++ b/src/main/resources/test/definitions/prisons/orphanage/ors-key-worker-case-notes-update-report.json
@@ -30,7 +30,7 @@
           "filterType": "autocomplete",
           "referenceType": "establishment",
           "reportFieldType": "string",
-          "display": "Establishment Code",
+          "display": "Establishment",
           "description": "@Prompt('Establishment Code','A','Establishment\\Establishment Code',mono,free,,Not_Persistent,,User:3)",
           "mandatory": "true"
         },

--- a/src/main/resources/test/definitions/prisons/orphanage/ors-key-worker-case-notes-update-report.json
+++ b/src/main/resources/test/definitions/prisons/orphanage/ors-key-worker-case-notes-update-report.json
@@ -27,7 +27,8 @@
         {
           "index": 0,
           "name": "establishment_code",
-          "filterType": "text",
+          "filterType": "autocomplete",
+          "referenceType": "establishment",
           "reportFieldType": "string",
           "display": "Establishment Code",
           "description": "@Prompt('Establishment Code','A','Establishment\\Establishment Code',mono,free,,Not_Persistent,,User:3)",
@@ -36,7 +37,8 @@
         {
           "index": 1,
           "name": "wing",
-          "filterType": "text",
+          "filterType": "autocomplete",
+          "referenceType": "wing",
           "reportFieldType": "string",
           "display": "Wing (All for all)",
           "description": "@Prompt('Wing (All for all)','A','Cell\\Level 1 Living Unit LOV',multi,free,,Not_Persistent,,User:4)",

--- a/src/main/resources/test/definitions/prisons/orphanage/ors-national-report-of-booked-visits.json
+++ b/src/main/resources/test/definitions/prisons/orphanage/ors-national-report-of-booked-visits.json
@@ -46,7 +46,7 @@
           "filterType": "autocomplete",
           "referenceType": "establishment",
           "reportFieldType": "string",
-          "display": "Establishment Code",
+          "display": "Establishment",
           "description": "@Prompt('Establishment Code','A','Establishment\\Establishment Code',mono,free,,Not_Persistent,,User:3)",
           "mandatory": "true"
         }

--- a/src/main/resources/test/definitions/prisons/orphanage/ors-national-report-of-booked-visits.json
+++ b/src/main/resources/test/definitions/prisons/orphanage/ors-national-report-of-booked-visits.json
@@ -43,7 +43,8 @@
         {
           "index": 2,
           "name": "establishment_code",
-          "filterType": "text",
+          "filterType": "autocomplete",
+          "referenceType": "establishment",
           "reportFieldType": "string",
           "display": "Establishment Code",
           "description": "@Prompt('Establishment Code','A','Establishment\\Establishment Code',mono,free,,Not_Persistent,,User:3)",

--- a/src/main/resources/test/definitions/prisons/orphanage/ors-oca-report-for-excel-reduced-version.json
+++ b/src/main/resources/test/definitions/prisons/orphanage/ors-oca-report-for-excel-reduced-version.json
@@ -188,7 +188,7 @@
           "filterType": "autocomplete",
           "referenceType": "establishment",
           "reportFieldType": "string",
-          "display": "Establishment Code",
+          "display": "Establishment",
           "description": "@Prompt('Establishment Code','A','Establishment\\Establishment Code',mono,free,,Not_Persistent,,User:3)",
           "mandatory": "true"
         }

--- a/src/main/resources/test/definitions/prisons/orphanage/ors-oca-report-for-excel-reduced-version.json
+++ b/src/main/resources/test/definitions/prisons/orphanage/ors-oca-report-for-excel-reduced-version.json
@@ -185,7 +185,8 @@
         {
           "index": 0,
           "name": "establishment_code",
-          "filterType": "text",
+          "filterType": "autocomplete",
+          "referenceType": "establishment",
           "reportFieldType": "string",
           "display": "Establishment Code",
           "description": "@Prompt('Establishment Code','A','Establishment\\Establishment Code',mono,free,,Not_Persistent,,User:3)",

--- a/src/main/resources/test/definitions/prisons/orphanage/ors-oca-report-for-excel.json
+++ b/src/main/resources/test/definitions/prisons/orphanage/ors-oca-report-for-excel.json
@@ -25,7 +25,8 @@
         {
           "index": 0,
           "name": "establishment_code",
-          "filterType": "text",
+          "filterType": "autocomplete",
+          "referenceType": "establishment",
           "reportFieldType": "string",
           "display": "Establishment Code",
           "description": "@Prompt('Establishment Code','A','Establishment/Establishment Code',mono,free,,Not_Persistent,,User:3)",
@@ -399,7 +400,8 @@
         {
           "index": 0,
           "name": "establishment_code",
-          "filterType": "text",
+          "filterType": "autocomplete",
+          "referenceType": "establishment",
           "reportFieldType": "string",
           "display": "Establishment Code",
           "description": "@Prompt('Establishment Code','A','Establishment/Establishment Code',mono,free,,Not_Persistent,,User:3)",
@@ -485,7 +487,8 @@
         {
           "index": 0,
           "name": "establishment_code",
-          "filterType": "text",
+          "filterType": "autocomplete",
+          "referenceType": "establishment",
           "reportFieldType": "string",
           "display": "Establishment Code",
           "description": "@Prompt('Establishment Code','A','Establishment/Establishment Code',mono,free,,Not_Persistent,,User:3)",
@@ -539,7 +542,8 @@
         {
           "index": 0,
           "name": "establishment_code",
-          "filterType": "text",
+          "filterType": "autocomplete",
+          "referenceType": "establishment",
           "reportFieldType": "string",
           "display": "Establishment Code",
           "description": "@Prompt('Establishment Code','A','Establishment/Establishment Code',mono,free,,Not_Persistent,,User:3)",
@@ -585,7 +589,8 @@
         {
           "index": 0,
           "name": "establishment_code",
-          "filterType": "text",
+          "filterType": "autocomplete",
+          "referenceType": "establishment",
           "reportFieldType": "string",
           "display": "Establishment Code",
           "description": "@Prompt('Establishment Code','A','Establishment/Establishment Code',mono,free,,Not_Persistent,,User:3)",
@@ -655,7 +660,8 @@
         {
           "index": 0,
           "name": "establishment_code",
-          "filterType": "text",
+          "filterType": "autocomplete",
+          "referenceType": "establishment",
           "reportFieldType": "string",
           "display": "Establishment Code",
           "description": "@Prompt('Establishment Code','A','Establishment/Establishment Code',mono,free,,Not_Persistent,,User:3)",
@@ -693,7 +699,8 @@
         {
           "index": 0,
           "name": "establishment_code",
-          "filterType": "text",
+          "filterType": "autocomplete",
+          "referenceType": "establishment",
           "reportFieldType": "string",
           "display": "Establishment Code",
           "description": "@Prompt('Establishment Code','A','Establishment/Establishment Code',mono,free,,Not_Persistent,,User:3)",

--- a/src/main/resources/test/definitions/prisons/orphanage/ors-oca-report-for-excel.json
+++ b/src/main/resources/test/definitions/prisons/orphanage/ors-oca-report-for-excel.json
@@ -28,7 +28,7 @@
           "filterType": "autocomplete",
           "referenceType": "establishment",
           "reportFieldType": "string",
-          "display": "Establishment Code",
+          "display": "Establishment",
           "description": "@Prompt('Establishment Code','A','Establishment/Establishment Code',mono,free,,Not_Persistent,,User:3)",
           "mandatory": "true"
         }
@@ -403,7 +403,7 @@
           "filterType": "autocomplete",
           "referenceType": "establishment",
           "reportFieldType": "string",
-          "display": "Establishment Code",
+          "display": "Establishment",
           "description": "@Prompt('Establishment Code','A','Establishment/Establishment Code',mono,free,,Not_Persistent,,User:3)",
           "mandatory": "true"
         }
@@ -490,7 +490,7 @@
           "filterType": "autocomplete",
           "referenceType": "establishment",
           "reportFieldType": "string",
-          "display": "Establishment Code",
+          "display": "Establishment",
           "description": "@Prompt('Establishment Code','A','Establishment/Establishment Code',mono,free,,Not_Persistent,,User:3)",
           "mandatory": "true"
         }
@@ -545,7 +545,7 @@
           "filterType": "autocomplete",
           "referenceType": "establishment",
           "reportFieldType": "string",
-          "display": "Establishment Code",
+          "display": "Establishment",
           "description": "@Prompt('Establishment Code','A','Establishment/Establishment Code',mono,free,,Not_Persistent,,User:3)",
           "mandatory": "true"
         }
@@ -592,7 +592,7 @@
           "filterType": "autocomplete",
           "referenceType": "establishment",
           "reportFieldType": "string",
-          "display": "Establishment Code",
+          "display": "Establishment",
           "description": "@Prompt('Establishment Code','A','Establishment/Establishment Code',mono,free,,Not_Persistent,,User:3)",
           "mandatory": "true"
         }
@@ -663,7 +663,7 @@
           "filterType": "autocomplete",
           "referenceType": "establishment",
           "reportFieldType": "string",
-          "display": "Establishment Code",
+          "display": "Establishment",
           "description": "@Prompt('Establishment Code','A','Establishment/Establishment Code',mono,free,,Not_Persistent,,User:3)",
           "mandatory": "true"
         }
@@ -702,7 +702,7 @@
           "filterType": "autocomplete",
           "referenceType": "establishment",
           "reportFieldType": "string",
-          "display": "Establishment Code",
+          "display": "Establishment",
           "description": "@Prompt('Establishment Code','A','Establishment/Establishment Code',mono,free,,Not_Persistent,,User:3)",
           "mandatory": "true"
         }

--- a/src/main/resources/test/definitions/prisons/orphanage/ors-official-and-social-visit-summary-report.json
+++ b/src/main/resources/test/definitions/prisons/orphanage/ors-official-and-social-visit-summary-report.json
@@ -43,7 +43,8 @@
         {
           "index": 2,
           "name": "establishment_code",
-          "filterType": "text",
+          "filterType": "autocomplete",
+          "referenceType": "establishment",
           "reportFieldType": "string",
           "display": "Enter value for Visit Establishment Code",
           "description": "@prompt('Enter value for Visit Establishment Code','A','Visits\\Visit Establishment Code',Multi,Free,Not_Persistent,,User:2)",
@@ -139,7 +140,8 @@
         {
           "index": 2,
           "name": "establishment_code",
-          "filterType": "text",
+          "filterType": "autocomplete",
+          "referenceType": "establishment",
           "reportFieldType": "string",
           "display": "Enter value for Visit Establishment Code",
           "description": "@prompt('Enter value for Visit Establishment Code','A','Visits\\Visit Establishment Code',Multi,Free,Not_Persistent,,User:2)",

--- a/src/main/resources/test/definitions/prisons/orphanage/ors-prisoner-and-visitors-details-report.json
+++ b/src/main/resources/test/definitions/prisons/orphanage/ors-prisoner-and-visitors-details-report.json
@@ -25,7 +25,8 @@
         {
           "index": 0,
           "name": "establishment_code",
-          "filterType": "text",
+          "filterType": "autocomplete",
+          "referenceType": "establishment",
           "reportFieldType": "string",
           "display": "Establishment Code",
           "description": "@Prompt('Establishment Code','A','Establishment\\Establishment Code',mono,free,,Not_Persistent,,User:3)",

--- a/src/main/resources/test/definitions/prisons/orphanage/ors-prisoner-and-visitors-details-report.json
+++ b/src/main/resources/test/definitions/prisons/orphanage/ors-prisoner-and-visitors-details-report.json
@@ -28,7 +28,7 @@
           "filterType": "autocomplete",
           "referenceType": "establishment",
           "reportFieldType": "string",
-          "display": "Establishment Code",
+          "display": "Establishment",
           "description": "@Prompt('Establishment Code','A','Establishment\\Establishment Code',mono,free,,Not_Persistent,,User:3)",
           "mandatory": "true"
         },

--- a/src/main/resources/test/definitions/prisons/orphanage/ors-prisoner-photographs.json
+++ b/src/main/resources/test/definitions/prisons/orphanage/ors-prisoner-photographs.json
@@ -25,7 +25,8 @@
         {
           "index": 0,
           "name": "establishment_code",
-          "filterType": "text",
+          "filterType": "autocomplete",
+          "referenceType": "establishment",
           "reportFieldType": "string",
           "display": "Establishment Code",
           "description": "@Prompt('Establishment Code','A','Establishment\\Establishment Code',mono,free,,Not_Persistent,,User:3)",
@@ -34,7 +35,8 @@
         {
           "index": 1,
           "name": "wing",
-          "filterType": "text",
+          "filterType": "autocomplete",
+          "referenceType": "wing",
           "reportFieldType": "string",
           "display": "Wing (All for all)",
           "description": "@Prompt('Wing (All for all)','A','Cell\\Location LOV',multi,free,,Not_Persistent,,User:4)",
@@ -136,7 +138,8 @@
         {
           "index": 0,
           "name": "establishment_code",
-          "filterType": "text",
+          "filterType": "autocomplete",
+          "referenceType": "establishment",
           "reportFieldType": "string",
           "display": "Establishment Code",
           "description": "@Prompt('Establishment Code','A','Establishment\\Establishment Code',mono,free,,Not_Persistent,,User:3)",
@@ -182,7 +185,8 @@
         {
           "index": 0,
           "name": "establishment_code",
-          "filterType": "text",
+          "filterType": "autocomplete",
+          "referenceType": "establishment",
           "reportFieldType": "string",
           "display": "Establishment Code",
           "description": "@Prompt('Establishment Code','A','Establishment\\Establishment Code',mono,free,,Not_Persistent,,User:3)",

--- a/src/main/resources/test/definitions/prisons/orphanage/ors-prisoner-photographs.json
+++ b/src/main/resources/test/definitions/prisons/orphanage/ors-prisoner-photographs.json
@@ -28,7 +28,7 @@
           "filterType": "autocomplete",
           "referenceType": "establishment",
           "reportFieldType": "string",
-          "display": "Establishment Code",
+          "display": "Establishment",
           "description": "@Prompt('Establishment Code','A','Establishment\\Establishment Code',mono,free,,Not_Persistent,,User:3)",
           "mandatory": "true"
         },
@@ -141,7 +141,7 @@
           "filterType": "autocomplete",
           "referenceType": "establishment",
           "reportFieldType": "string",
-          "display": "Establishment Code",
+          "display": "Establishment",
           "description": "@Prompt('Establishment Code','A','Establishment\\Establishment Code',mono,free,,Not_Persistent,,User:3)",
           "mandatory": "true"
         }
@@ -188,7 +188,7 @@
           "filterType": "autocomplete",
           "referenceType": "establishment",
           "reportFieldType": "string",
-          "display": "Establishment Code",
+          "display": "Establishment",
           "description": "@Prompt('Establishment Code','A','Establishment\\Establishment Code',mono,free,,Not_Persistent,,User:3)",
           "mandatory": "true"
         }

--- a/src/main/resources/test/definitions/prisons/orphanage/ors-prisoner-religion.json
+++ b/src/main/resources/test/definitions/prisons/orphanage/ors-prisoner-religion.json
@@ -27,7 +27,8 @@
         {
           "index": 0,
           "name": "establishment_code",
-          "filterType": "text",
+          "filterType": "autocomplete",
+          "referenceType": "establishment",
           "reportFieldType": "string",
           "display": "Establishment Code",
           "description": "@Prompt('Establishment Code','A','Establishment\\Establishment Code',mono,free,,Not_Persistent,,User:3)",

--- a/src/main/resources/test/definitions/prisons/orphanage/ors-prisoner-religion.json
+++ b/src/main/resources/test/definitions/prisons/orphanage/ors-prisoner-religion.json
@@ -30,7 +30,7 @@
           "filterType": "autocomplete",
           "referenceType": "establishment",
           "reportFieldType": "string",
-          "display": "Establishment Code",
+          "display": "Establishment",
           "description": "@Prompt('Establishment Code','A','Establishment\\Establishment Code',mono,free,,Not_Persistent,,User:3)",
           "mandatory": "true"
         }

--- a/src/main/resources/test/definitions/prisons/orphanage/ors-prisoners-at-court.json
+++ b/src/main/resources/test/definitions/prisons/orphanage/ors-prisoners-at-court.json
@@ -25,7 +25,8 @@
         {
           "index": 0,
           "name": "establishment_code",
-          "filterType": "text",
+          "filterType": "autocomplete",
+          "referenceType": "establishment",
           "reportFieldType": "string",
           "display": "Establishment Code",
           "description": "@Prompt('Establishment Code','A','Establishment\\Establishment Code',mono,free,,Not_Persistent,,User:3)",

--- a/src/main/resources/test/definitions/prisons/orphanage/ors-prisoners-at-court.json
+++ b/src/main/resources/test/definitions/prisons/orphanage/ors-prisoners-at-court.json
@@ -28,7 +28,7 @@
           "filterType": "autocomplete",
           "referenceType": "establishment",
           "reportFieldType": "string",
-          "display": "Establishment Code",
+          "display": "Establishment",
           "description": "@Prompt('Establishment Code','A','Establishment\\Establishment Code',mono,free,,Not_Persistent,,User:3)",
           "mandatory": "true"
         }

--- a/src/main/resources/test/definitions/prisons/orphanage/ors-prisoners-in-reception-court-or-cswap-more-than-a-day-with-additional-grace-period.json
+++ b/src/main/resources/test/definitions/prisons/orphanage/ors-prisoners-in-reception-court-or-cswap-more-than-a-day-with-additional-grace-period.json
@@ -25,7 +25,8 @@
         {
           "index": 0,
           "name": "establishment_code",
-          "filterType": "text",
+          "filterType": "autocomplete",
+          "referenceType": "establishment",
           "reportFieldType": "string",
           "display": "Establishment Code",
           "description": "@Prompt('Establishment Code','A','Establishment\\Establishment Code',mono,free,,Not_Persistent,,User:3)",

--- a/src/main/resources/test/definitions/prisons/orphanage/ors-prisoners-in-reception-court-or-cswap-more-than-a-day-with-additional-grace-period.json
+++ b/src/main/resources/test/definitions/prisons/orphanage/ors-prisoners-in-reception-court-or-cswap-more-than-a-day-with-additional-grace-period.json
@@ -28,7 +28,7 @@
           "filterType": "autocomplete",
           "referenceType": "establishment",
           "reportFieldType": "string",
-          "display": "Establishment Code",
+          "display": "Establishment",
           "description": "@Prompt('Establishment Code','A','Establishment\\Establishment Code',mono,free,,Not_Persistent,,User:3)",
           "mandatory": "true"
         }

--- a/src/main/resources/test/definitions/prisons/orphanage/ors-prisoners-missing-ethnicity.json
+++ b/src/main/resources/test/definitions/prisons/orphanage/ors-prisoners-missing-ethnicity.json
@@ -27,7 +27,8 @@
         {
           "index": 0,
           "name": "establishment_code",
-          "filterType": "text",
+          "filterType": "autocomplete",
+          "referenceType": "establishment",
           "reportFieldType": "string",
           "display": "Establishment Code",
           "description": "@Prompt('Establishment Code','A','Establishment\\Establishment Code',mono,free,,Not_Persistent,,User:3)",

--- a/src/main/resources/test/definitions/prisons/orphanage/ors-prisoners-missing-ethnicity.json
+++ b/src/main/resources/test/definitions/prisons/orphanage/ors-prisoners-missing-ethnicity.json
@@ -30,7 +30,7 @@
           "filterType": "autocomplete",
           "referenceType": "establishment",
           "reportFieldType": "string",
-          "display": "Establishment Code",
+          "display": "Establishment",
           "description": "@Prompt('Establishment Code','A','Establishment\\Establishment Code',mono,free,,Not_Persistent,,User:3)",
           "mandatory": "true"
         }

--- a/src/main/resources/test/definitions/prisons/orphanage/ors-prisoners-missing-nationality.json
+++ b/src/main/resources/test/definitions/prisons/orphanage/ors-prisoners-missing-nationality.json
@@ -27,7 +27,8 @@
         {
           "index": 0,
           "name": "establishment_code",
-          "filterType": "text",
+          "filterType": "autocomplete",
+          "referenceType": "establishment",
           "reportFieldType": "string",
           "display": "Establishment Code",
           "description": "@Prompt('Establishment Code','A','Establishment\\Establishment Code',mono,free,,Not_Persistent,,User:3)",

--- a/src/main/resources/test/definitions/prisons/orphanage/ors-prisoners-missing-nationality.json
+++ b/src/main/resources/test/definitions/prisons/orphanage/ors-prisoners-missing-nationality.json
@@ -30,7 +30,7 @@
           "filterType": "autocomplete",
           "referenceType": "establishment",
           "reportFieldType": "string",
-          "display": "Establishment Code",
+          "display": "Establishment",
           "description": "@Prompt('Establishment Code','A','Establishment\\Establishment Code',mono,free,,Not_Persistent,,User:3)",
           "mandatory": "true"
         }

--- a/src/main/resources/test/definitions/prisons/orphanage/ors-prisoners-missing-next-of-kin-contact.json
+++ b/src/main/resources/test/definitions/prisons/orphanage/ors-prisoners-missing-next-of-kin-contact.json
@@ -27,7 +27,8 @@
         {
           "index": 0,
           "name": "establishment_code",
-          "filterType": "text",
+          "filterType": "autocomplete",
+          "referenceType": "establishment",
           "reportFieldType": "string",
           "display": "Establishment Code",
           "description": "@Prompt('Establishment Code','A','Establishment\\Establishment Code',mono,free,,Not_Persistent,,User:3)",

--- a/src/main/resources/test/definitions/prisons/orphanage/ors-prisoners-missing-next-of-kin-contact.json
+++ b/src/main/resources/test/definitions/prisons/orphanage/ors-prisoners-missing-next-of-kin-contact.json
@@ -30,7 +30,7 @@
           "filterType": "autocomplete",
           "referenceType": "establishment",
           "reportFieldType": "string",
-          "display": "Establishment Code",
+          "display": "Establishment",
           "description": "@Prompt('Establishment Code','A','Establishment\\Establishment Code',mono,free,,Not_Persistent,,User:3)",
           "mandatory": "true"
         }

--- a/src/main/resources/test/definitions/prisons/orphanage/ors-prisoners-missing-religion.json
+++ b/src/main/resources/test/definitions/prisons/orphanage/ors-prisoners-missing-religion.json
@@ -27,7 +27,8 @@
         {
           "index": 0,
           "name": "establishment_code",
-          "filterType": "text",
+          "filterType": "autocomplete",
+          "referenceType": "establishment",
           "reportFieldType": "string",
           "display": "Establishment Code",
           "description": "@Prompt('Establishment Code','A','Establishment\\Establishment Code',mono,free,,Not_Persistent,,User:3)",

--- a/src/main/resources/test/definitions/prisons/orphanage/ors-prisoners-missing-religion.json
+++ b/src/main/resources/test/definitions/prisons/orphanage/ors-prisoners-missing-religion.json
@@ -30,7 +30,7 @@
           "filterType": "autocomplete",
           "referenceType": "establishment",
           "reportFieldType": "string",
-          "display": "Establishment Code",
+          "display": "Establishment",
           "description": "@Prompt('Establishment Code','A','Establishment\\Establishment Code',mono,free,,Not_Persistent,,User:3)",
           "mandatory": "true"
         }

--- a/src/main/resources/test/definitions/prisons/orphanage/ors-prisoners-with-no-visit-history.json
+++ b/src/main/resources/test/definitions/prisons/orphanage/ors-prisoners-with-no-visit-history.json
@@ -25,7 +25,8 @@
         {
           "index": 0,
           "name": "establishment_code",
-          "filterType": "text",
+          "filterType": "autocomplete",
+          "referenceType": "establishment",
           "reportFieldType": "string",
           "display": "Establishment Code",
           "description": "@Prompt('Establishment Code','A','Establishment\\Establishment Code',mono,free,,Not_Persistent,,User:3)",

--- a/src/main/resources/test/definitions/prisons/orphanage/ors-prisoners-with-no-visit-history.json
+++ b/src/main/resources/test/definitions/prisons/orphanage/ors-prisoners-with-no-visit-history.json
@@ -28,7 +28,7 @@
           "filterType": "autocomplete",
           "referenceType": "establishment",
           "reportFieldType": "string",
-          "display": "Establishment Code",
+          "display": "Establishment",
           "description": "@Prompt('Establishment Code','A','Establishment\\Establishment Code',mono,free,,Not_Persistent,,User:3)",
           "mandatory": "true"
         }

--- a/src/main/resources/test/definitions/prisons/orphanage/ors-prisoners-without-a-social-visit-for-a-date-range.json
+++ b/src/main/resources/test/definitions/prisons/orphanage/ors-prisoners-without-a-social-visit-for-a-date-range.json
@@ -28,7 +28,7 @@
           "filterType": "autocomplete",
           "referenceType": "establishment",
           "reportFieldType": "string",
-          "display": "Establishment Code",
+          "display": "Establishment",
           "description": "@Prompt('Establishment Code','A','Establishment\\Establishment Code',mono,free,,Not_Persistent,,User:3)",
           "mandatory": "true"
         },
@@ -164,7 +164,7 @@
           "filterType": "autocomplete",
           "referenceType": "establishment",
           "reportFieldType": "string",
-          "display": "Establishment Code",
+          "display": "Establishment",
           "description": "@Prompt('Establishment Code','A','Establishment\\Establishment Code',mono,free,,Not_Persistent,,User:3)",
           "mandatory": "true"
         },
@@ -236,7 +236,7 @@
           "filterType": "autocomplete",
           "referenceType": "establishment",
           "reportFieldType": "string",
-          "display": "Establishment Code",
+          "display": "Establishment",
           "description": "@Prompt('Establishment Code','A','Establishment\\Establishment Code',mono,free,,Not_Persistent,,User:3)",
           "mandatory": "true"
         }
@@ -347,7 +347,7 @@
           "filterType": "autocomplete",
           "referenceType": "establishment",
           "reportFieldType": "string",
-          "display": "Establishment Code",
+          "display": "Establishment",
           "description": "@Prompt('Establishment Code','A','Establishment\\Establishment Code',mono,free,,Not_Persistent,,User:3)",
           "mandatory": "true"
         }
@@ -394,7 +394,7 @@
           "filterType": "autocomplete",
           "referenceType": "establishment",
           "reportFieldType": "string",
-          "display": "Establishment Code",
+          "display": "Establishment",
           "description": "@Prompt('Establishment Code','A','Establishment\\Establishment Code',mono,free,,Not_Persistent,,User:3)",
           "mandatory": "true"
         }
@@ -441,7 +441,7 @@
           "filterType": "autocomplete",
           "referenceType": "establishment",
           "reportFieldType": "string",
-          "display": "Establishment Code",
+          "display": "Establishment",
           "description": "@Prompt('Establishment Code','A','Establishment\\Establishment Code',mono,free,,Not_Persistent,,User:3)",
           "mandatory": "true"
         }
@@ -488,7 +488,7 @@
           "filterType": "autocomplete",
           "referenceType": "establishment",
           "reportFieldType": "string",
-          "display": "Establishment Code",
+          "display": "Establishment",
           "description": "@Prompt('Establishment Code','A','Establishment\\Establishment Code',mono,free,,Not_Persistent,,User:3)",
           "mandatory": "true"
         }

--- a/src/main/resources/test/definitions/prisons/orphanage/ors-prisoners-without-a-social-visit-for-a-date-range.json
+++ b/src/main/resources/test/definitions/prisons/orphanage/ors-prisoners-without-a-social-visit-for-a-date-range.json
@@ -25,7 +25,8 @@
         {
           "index": 0,
           "name": "establishment_code",
-          "filterType": "text",
+          "filterType": "autocomplete",
+          "referenceType": "establishment",
           "reportFieldType": "string",
           "display": "Establishment Code",
           "description": "@Prompt('Establishment Code','A','Establishment\\Establishment Code',mono,free,,Not_Persistent,,User:3)",
@@ -160,7 +161,8 @@
         {
           "index": 0,
           "name": "establishment_code",
-          "filterType": "text",
+          "filterType": "autocomplete",
+          "referenceType": "establishment",
           "reportFieldType": "string",
           "display": "Establishment Code",
           "description": "@Prompt('Establishment Code','A','Establishment\\Establishment Code',mono,free,,Not_Persistent,,User:3)",
@@ -231,7 +233,8 @@
         {
           "index": 0,
           "name": "establishment_code",
-          "filterType": "text",
+          "filterType": "autocomplete",
+          "referenceType": "establishment",
           "reportFieldType": "string",
           "display": "Establishment Code",
           "description": "@Prompt('Establishment Code','A','Establishment\\Establishment Code',mono,free,,Not_Persistent,,User:3)",
@@ -341,7 +344,8 @@
         {
           "index": 0,
           "name": "establishment_code",
-          "filterType": "text",
+          "filterType": "autocomplete",
+          "referenceType": "establishment",
           "reportFieldType": "string",
           "display": "Establishment Code",
           "description": "@Prompt('Establishment Code','A','Establishment\\Establishment Code',mono,free,,Not_Persistent,,User:3)",
@@ -387,7 +391,8 @@
         {
           "index": 0,
           "name": "establishment_code",
-          "filterType": "text",
+          "filterType": "autocomplete",
+          "referenceType": "establishment",
           "reportFieldType": "string",
           "display": "Establishment Code",
           "description": "@Prompt('Establishment Code','A','Establishment\\Establishment Code',mono,free,,Not_Persistent,,User:3)",
@@ -433,7 +438,8 @@
         {
           "index": 0,
           "name": "establishment_code",
-          "filterType": "text",
+          "filterType": "autocomplete",
+          "referenceType": "establishment",
           "reportFieldType": "string",
           "display": "Establishment Code",
           "description": "@Prompt('Establishment Code','A','Establishment\\Establishment Code',mono,free,,Not_Persistent,,User:3)",
@@ -479,7 +485,8 @@
         {
           "index": 0,
           "name": "establishment_code",
-          "filterType": "text",
+          "filterType": "autocomplete",
+          "referenceType": "establishment",
           "reportFieldType": "string",
           "display": "Establishment Code",
           "description": "@Prompt('Establishment Code','A','Establishment\\Establishment Code',mono,free,,Not_Persistent,,User:3)",

--- a/src/main/resources/test/definitions/prisons/orphanage/ors-prisoners-without-visit-history.json
+++ b/src/main/resources/test/definitions/prisons/orphanage/ors-prisoners-without-visit-history.json
@@ -25,7 +25,8 @@
         {
           "index": 0,
           "name": "establishment_code",
-          "filterType": "text",
+          "filterType": "autocomplete",
+          "referenceType": "establishment",
           "reportFieldType": "string",
           "display": "Establishment Code",
           "description": "@prompt('Establishment Code','A','Visit History\\Establishment Code Where Visit Held',Mono,Free,Not_Persistent,,User:2)",

--- a/src/main/resources/test/definitions/prisons/orphanage/ors-prisoners-without-visit-history.json
+++ b/src/main/resources/test/definitions/prisons/orphanage/ors-prisoners-without-visit-history.json
@@ -28,7 +28,7 @@
           "filterType": "autocomplete",
           "referenceType": "establishment",
           "reportFieldType": "string",
-          "display": "Establishment Code",
+          "display": "Establishment",
           "description": "@prompt('Establishment Code','A','Visit History\\Establishment Code Where Visit Held',Mono,Free,Not_Persistent,,User:2)",
           "mandatory": "true"
         }

--- a/src/main/resources/test/definitions/prisons/orphanage/ors-property-box-allocation-to-active-prisoners.json
+++ b/src/main/resources/test/definitions/prisons/orphanage/ors-property-box-allocation-to-active-prisoners.json
@@ -25,7 +25,8 @@
         {
           "index": 0,
           "name": "establishment_code",
-          "filterType": "text",
+          "filterType": "autocomplete",
+          "referenceType": "establishment",
           "reportFieldType": "string",
           "display": "Establishment Code",
           "description": "@Prompt('Establishment Code','A','Establishment\\Establishment Code',mono,free,,Not_Persistent,,User:3)",
@@ -127,7 +128,8 @@
         {
           "index": 0,
           "name": "establishment_code",
-          "filterType": "text",
+          "filterType": "autocomplete",
+          "referenceType": "establishment",
           "reportFieldType": "string",
           "display": "Establishment Code",
           "description": "@prompt('Establishment Code','A','Establishment\\Establishment Code',Mono,Free,Not_Persistent,,User:0)",

--- a/src/main/resources/test/definitions/prisons/orphanage/ors-property-box-allocation-to-active-prisoners.json
+++ b/src/main/resources/test/definitions/prisons/orphanage/ors-property-box-allocation-to-active-prisoners.json
@@ -28,7 +28,7 @@
           "filterType": "autocomplete",
           "referenceType": "establishment",
           "reportFieldType": "string",
-          "display": "Establishment Code",
+          "display": "Establishment",
           "description": "@Prompt('Establishment Code','A','Establishment\\Establishment Code',mono,free,,Not_Persistent,,User:3)",
           "mandatory": "true"
         }
@@ -131,7 +131,7 @@
           "filterType": "autocomplete",
           "referenceType": "establishment",
           "reportFieldType": "string",
-          "display": "Establishment Code",
+          "display": "Establishment",
           "description": "@prompt('Establishment Code','A','Establishment\\Establishment Code',Mono,Free,Not_Persistent,,User:0)",
           "mandatory": "true"
         }

--- a/src/main/resources/test/definitions/prisons/orphanage/ors-property-box-error-report.json
+++ b/src/main/resources/test/definitions/prisons/orphanage/ors-property-box-error-report.json
@@ -25,7 +25,8 @@
         {
           "index": 0,
           "name": "establishment_code",
-          "filterType": "text",
+          "filterType": "autocomplete",
+          "referenceType": "establishment",
           "reportFieldType": "string",
           "display": "Establishment Code",
           "description": "@Prompt('Establishment Code','A','Establishment\\Establishment Code',mono,free,,Not_Persistent,,User:3)",

--- a/src/main/resources/test/definitions/prisons/orphanage/ors-property-box-error-report.json
+++ b/src/main/resources/test/definitions/prisons/orphanage/ors-property-box-error-report.json
@@ -28,7 +28,7 @@
           "filterType": "autocomplete",
           "referenceType": "establishment",
           "reportFieldType": "string",
-          "display": "Establishment Code",
+          "display": "Establishment",
           "description": "@Prompt('Establishment Code','A','Establishment\\Establishment Code',mono,free,,Not_Persistent,,User:3)",
           "mandatory": "true"
         }

--- a/src/main/resources/test/definitions/prisons/orphanage/ors-property-boxes-at-an-establishment.json
+++ b/src/main/resources/test/definitions/prisons/orphanage/ors-property-boxes-at-an-establishment.json
@@ -25,7 +25,8 @@
         {
           "index": 0,
           "name": "establishment_code",
-          "filterType": "text",
+          "filterType": "autocomplete",
+          "referenceType": "establishment",
           "reportFieldType": "string",
           "display": "Establishment Code",
           "description": "@Prompt('Establishment Code','A','Establishment\\Establishment Code',mono,free,,Not_Persistent,,User:3)",

--- a/src/main/resources/test/definitions/prisons/orphanage/ors-property-boxes-at-an-establishment.json
+++ b/src/main/resources/test/definitions/prisons/orphanage/ors-property-boxes-at-an-establishment.json
@@ -28,7 +28,7 @@
           "filterType": "autocomplete",
           "referenceType": "establishment",
           "reportFieldType": "string",
-          "display": "Establishment Code",
+          "display": "Establishment",
           "description": "@Prompt('Establishment Code','A','Establishment\\Establishment Code',mono,free,,Not_Persistent,,User:3)",
           "mandatory": "true"
         }

--- a/src/main/resources/test/definitions/prisons/orphanage/ors-property-location-history.json
+++ b/src/main/resources/test/definitions/prisons/orphanage/ors-property-location-history.json
@@ -25,7 +25,8 @@
         {
           "index": 0,
           "name": "establishment_code",
-          "filterType": "text",
+          "filterType": "autocomplete",
+          "referenceType": "establishment",
           "reportFieldType": "string",
           "display": "Establishment Code",
           "description": "@Prompt('Establishment Code','A','Establishment\\Establishment Code',mono,free,,Not_Persistent,,User:3)",

--- a/src/main/resources/test/definitions/prisons/orphanage/ors-property-location-history.json
+++ b/src/main/resources/test/definitions/prisons/orphanage/ors-property-location-history.json
@@ -28,7 +28,7 @@
           "filterType": "autocomplete",
           "referenceType": "establishment",
           "reportFieldType": "string",
-          "display": "Establishment Code",
+          "display": "Establishment",
           "description": "@Prompt('Establishment Code','A','Establishment\\Establishment Code',mono,free,,Not_Persistent,,User:3)",
           "mandatory": "true"
         }

--- a/src/main/resources/test/definitions/prisons/orphanage/ors-resettlement-ete.json
+++ b/src/main/resources/test/definitions/prisons/orphanage/ors-resettlement-ete.json
@@ -25,7 +25,8 @@
         {
           "index": 0,
           "name": "establishment_code",
-          "filterType": "text",
+          "filterType": "autocomplete",
+          "referenceType": "establishment",
           "reportFieldType": "string",
           "display": "Discharge Location Code",
           "description": "@Prompt('Discharge Location Code','A','Establishment\\Establishment Code',mono,free,,Not_Persistent,,User:0)",

--- a/src/main/resources/test/definitions/prisons/orphanage/ors-scheduled-court-and-transfer-movements-with-date-range-prompt.json
+++ b/src/main/resources/test/definitions/prisons/orphanage/ors-scheduled-court-and-transfer-movements-with-date-range-prompt.json
@@ -28,7 +28,7 @@
           "filterType": "autocomplete",
           "referenceType": "establishment",
           "reportFieldType": "string",
-          "display": "Establishment Code",
+          "display": "Establishment",
           "description": "@Prompt('Establishment Code','A','Establishment\\Establishment Code',mono,free,,Not_Persistent,,User:3)",
           "mandatory": "true"
         },
@@ -309,7 +309,7 @@
           "filterType": "autocomplete",
           "referenceType": "establishment",
           "reportFieldType": "string",
-          "display": "Establishment Code",
+          "display": "Establishment",
           "description": "@Prompt('Establishment Code','A','Establishment\\Establishment Code',mono,free,,Not_Persistent,,User:3)",
           "mandatory": "true"
         }
@@ -340,7 +340,7 @@
           "filterType": "autocomplete",
           "referenceType": "establishment",
           "reportFieldType": "string",
-          "display": "Establishment Code",
+          "display": "Establishment",
           "description": "@Prompt('Establishment Code','A','Establishment\\Establishment Code',mono,free,,Not_Persistent,,User:3)",
           "mandatory": "true"
         }

--- a/src/main/resources/test/definitions/prisons/orphanage/ors-scheduled-court-and-transfer-movements-with-date-range-prompt.json
+++ b/src/main/resources/test/definitions/prisons/orphanage/ors-scheduled-court-and-transfer-movements-with-date-range-prompt.json
@@ -25,7 +25,8 @@
         {
           "index": 0,
           "name": "establishment_code",
-          "filterType": "text",
+          "filterType": "autocomplete",
+          "referenceType": "establishment",
           "reportFieldType": "string",
           "display": "Establishment Code",
           "description": "@Prompt('Establishment Code','A','Establishment\\Establishment Code',mono,free,,Not_Persistent,,User:3)",
@@ -305,7 +306,8 @@
         {
           "index": 0,
           "name": "establishment_code",
-          "filterType": "text",
+          "filterType": "autocomplete",
+          "referenceType": "establishment",
           "reportFieldType": "string",
           "display": "Establishment Code",
           "description": "@Prompt('Establishment Code','A','Establishment\\Establishment Code',mono,free,,Not_Persistent,,User:3)",
@@ -335,7 +337,8 @@
         {
           "index": 0,
           "name": "establishment_code",
-          "filterType": "text",
+          "filterType": "autocomplete",
+          "referenceType": "establishment",
           "reportFieldType": "string",
           "display": "Establishment Code",
           "description": "@Prompt('Establishment Code','A','Establishment\\Establishment Code',mono,free,,Not_Persistent,,User:3)",

--- a/src/main/resources/test/definitions/prisons/orphanage/ors-scheduled-court-and-transfer-movements.json
+++ b/src/main/resources/test/definitions/prisons/orphanage/ors-scheduled-court-and-transfer-movements.json
@@ -25,7 +25,8 @@
         {
           "index": 0,
           "name": "establishment_code",
-          "filterType": "text",
+          "filterType": "autocomplete",
+          "referenceType": "establishment",
           "reportFieldType": "string",
           "display": "Establishment Code",
           "description": "@Prompt('Establishment Code','A','Establishment\\Establishment Code',mono,free,,Not_Persistent,,User:3)",
@@ -297,7 +298,8 @@
         {
           "index": 0,
           "name": "establishment_code",
-          "filterType": "text",
+          "filterType": "autocomplete",
+          "referenceType": "establishment",
           "reportFieldType": "string",
           "display": "Establishment Code",
           "description": "@Prompt('Establishment Code','A','Establishment\\Establishment Code',mono,free,,Not_Persistent,,User:3)",
@@ -327,7 +329,8 @@
         {
           "index": 0,
           "name": "establishment_code",
-          "filterType": "text",
+          "filterType": "autocomplete",
+          "referenceType": "establishment",
           "reportFieldType": "string",
           "display": "Establishment Code",
           "description": "@Prompt('Establishment Code','A','Establishment\\Establishment Code',mono,free,,Not_Persistent,,User:3)",

--- a/src/main/resources/test/definitions/prisons/orphanage/ors-scheduled-court-and-transfer-movements.json
+++ b/src/main/resources/test/definitions/prisons/orphanage/ors-scheduled-court-and-transfer-movements.json
@@ -28,7 +28,7 @@
           "filterType": "autocomplete",
           "referenceType": "establishment",
           "reportFieldType": "string",
-          "display": "Establishment Code",
+          "display": "Establishment",
           "description": "@Prompt('Establishment Code','A','Establishment\\Establishment Code',mono,free,,Not_Persistent,,User:3)",
           "mandatory": "true"
         },
@@ -301,7 +301,7 @@
           "filterType": "autocomplete",
           "referenceType": "establishment",
           "reportFieldType": "string",
-          "display": "Establishment Code",
+          "display": "Establishment",
           "description": "@Prompt('Establishment Code','A','Establishment\\Establishment Code',mono,free,,Not_Persistent,,User:3)",
           "mandatory": "true"
         }
@@ -332,7 +332,7 @@
           "filterType": "autocomplete",
           "referenceType": "establishment",
           "reportFieldType": "string",
-          "display": "Establishment Code",
+          "display": "Establishment",
           "description": "@Prompt('Establishment Code','A','Establishment\\Establishment Code',mono,free,,Not_Persistent,,User:3)",
           "mandatory": "true"
         }

--- a/src/main/resources/test/definitions/prisons/orphanage/ors-scheduled-rotl-movements.json
+++ b/src/main/resources/test/definitions/prisons/orphanage/ors-scheduled-rotl-movements.json
@@ -25,7 +25,8 @@
         {
           "index": 0,
           "name": "establishment_code",
-          "filterType": "text",
+          "filterType": "autocomplete",
+          "referenceType": "establishment",
           "reportFieldType": "string",
           "display": "Establishment Code",
           "description": "@Prompt('Establishment Code','A','Establishment\\Establishment Code',mono,free,,Not_Persistent,,User:3)",

--- a/src/main/resources/test/definitions/prisons/orphanage/ors-scheduled-rotl-movements.json
+++ b/src/main/resources/test/definitions/prisons/orphanage/ors-scheduled-rotl-movements.json
@@ -28,7 +28,7 @@
           "filterType": "autocomplete",
           "referenceType": "establishment",
           "reportFieldType": "string",
-          "display": "Establishment Code",
+          "display": "Establishment",
           "description": "@Prompt('Establishment Code','A','Establishment\\Establishment Code',mono,free,,Not_Persistent,,User:3)",
           "mandatory": "true"
         },

--- a/src/main/resources/test/definitions/prisons/orphanage/ors-security-movements.json
+++ b/src/main/resources/test/definitions/prisons/orphanage/ors-security-movements.json
@@ -43,7 +43,8 @@
         {
           "index": 2,
           "name": "establishment_code",
-          "filterType": "text",
+          "filterType": "autocomplete",
+          "referenceType": "establishment",
           "reportFieldType": "string",
           "display": "Establishment Code",
           "description": "@Prompt('Establishment Code','A','Establishment\\Establishment Code',mono,free,,Not_Persistent,,User:3)",
@@ -179,7 +180,8 @@
         {
           "index": 2,
           "name": "establishment_code",
-          "filterType": "text",
+          "filterType": "autocomplete",
+          "referenceType": "establishment",
           "reportFieldType": "string",
           "display": "Establishment Code",
           "description": "@Prompt('Establishment Code','A','Establishment\\Establishment Code',mono,free,,Not_Persistent,,User:3)",

--- a/src/main/resources/test/definitions/prisons/orphanage/ors-security-movements.json
+++ b/src/main/resources/test/definitions/prisons/orphanage/ors-security-movements.json
@@ -46,7 +46,7 @@
           "filterType": "autocomplete",
           "referenceType": "establishment",
           "reportFieldType": "string",
-          "display": "Establishment Code",
+          "display": "Establishment",
           "description": "@Prompt('Establishment Code','A','Establishment\\Establishment Code',mono,free,,Not_Persistent,,User:3)",
           "mandatory": "true"
         }
@@ -183,7 +183,7 @@
           "filterType": "autocomplete",
           "referenceType": "establishment",
           "reportFieldType": "string",
-          "display": "Establishment Code",
+          "display": "Establishment",
           "description": "@Prompt('Establishment Code','A','Establishment\\Establishment Code',mono,free,,Not_Persistent,,User:3)",
           "mandatory": "true"
         }

--- a/src/main/resources/test/definitions/prisons/orphanage/ors-site-visit.json
+++ b/src/main/resources/test/definitions/prisons/orphanage/ors-site-visit.json
@@ -25,7 +25,8 @@
         {
           "index": 0,
           "name": "establishment_code",
-          "filterType": "text",
+          "filterType": "autocomplete",
+          "referenceType": "establishment",
           "reportFieldType": "string",
           "display": "Establishment Code",
           "description": "@Prompt('Establishment Code','A','Establishment\\Establishment Code',mono,free,,Not_Persistent,,User:3)",

--- a/src/main/resources/test/definitions/prisons/orphanage/ors-site-visit.json
+++ b/src/main/resources/test/definitions/prisons/orphanage/ors-site-visit.json
@@ -28,7 +28,7 @@
           "filterType": "autocomplete",
           "referenceType": "establishment",
           "reportFieldType": "string",
-          "display": "Establishment Code",
+          "display": "Establishment",
           "description": "@Prompt('Establishment Code','A','Establishment\\Establishment Code',mono,free,,Not_Persistent,,User:3)",
           "mandatory": "true"
         }

--- a/src/main/resources/test/definitions/prisons/orphanage/ors-social-visit-history-with-protected-characteristics.json
+++ b/src/main/resources/test/definitions/prisons/orphanage/ors-social-visit-history-with-protected-characteristics.json
@@ -25,7 +25,8 @@
         {
           "index": 0,
           "name": "establishment_code",
-          "filterType": "text",
+          "filterType": "autocomplete",
+          "referenceType": "establishment",
           "reportFieldType": "string",
           "display": "Establishment Code",
           "description": "@Prompt('Establishment Code','A','Establishment\\Establishment Code',mono,free,,Not_Persistent,,User:3)",
@@ -123,7 +124,8 @@
         {
           "index": 0,
           "name": "establishment_code",
-          "filterType": "text",
+          "filterType": "autocomplete",
+          "referenceType": "establishment",
           "reportFieldType": "string",
           "display": "Establishment Code",
           "description": "@Prompt('Establishment Code','A','Establishment\\Establishment Code',mono,free,,Not_Persistent,,User:3)",
@@ -370,7 +372,8 @@
         {
           "index": 0,
           "name": "establishment_code",
-          "filterType": "text",
+          "filterType": "autocomplete",
+          "referenceType": "establishment",
           "reportFieldType": "string",
           "display": "Establishment Code",
           "description": "@Prompt('Establishment Code','A','Establishment\\Establishment Code',mono,free,,Not_Persistent,,User:3)",
@@ -408,7 +411,8 @@
         {
           "index": 0,
           "name": "establishment_code",
-          "filterType": "text",
+          "filterType": "autocomplete",
+          "referenceType": "establishment",
           "reportFieldType": "string",
           "display": "Establishment Code",
           "description": "@Prompt('Establishment Code','A','Establishment\\Establishment Code',mono,free,,Not_Persistent,,User:3)",
@@ -454,7 +458,8 @@
         {
           "index": 0,
           "name": "establishment_code",
-          "filterType": "text",
+          "filterType": "autocomplete",
+          "referenceType": "establishment",
           "reportFieldType": "string",
           "display": "Establishment Code",
           "description": "@Prompt('Establishment Code','A','Establishment\\Establishment Code',mono,free,,Not_Persistent,,User:3)",
@@ -526,7 +531,8 @@
         {
           "index": 0,
           "name": "establishment_code",
-          "filterType": "text",
+          "filterType": "autocomplete",
+          "referenceType": "establishment",
           "reportFieldType": "string",
           "display": "Establishment Code",
           "description": "@Prompt('Establishment Code','A','Establishment\\Establishment Code',mono,free,,Not_Persistent,,User:3)",
@@ -685,7 +691,8 @@
         {
           "index": 0,
           "name": "establishment_code",
-          "filterType": "text",
+          "filterType": "autocomplete",
+          "referenceType": "establishment",
           "reportFieldType": "string",
           "display": "Establishment Code",
           "description": "@Prompt('Establishment Code','A','Establishment\\Establishment Code',mono,free,,Not_Persistent,,User:3)",

--- a/src/main/resources/test/definitions/prisons/orphanage/ors-social-visit-history-with-protected-characteristics.json
+++ b/src/main/resources/test/definitions/prisons/orphanage/ors-social-visit-history-with-protected-characteristics.json
@@ -28,7 +28,7 @@
           "filterType": "autocomplete",
           "referenceType": "establishment",
           "reportFieldType": "string",
-          "display": "Establishment Code",
+          "display": "Establishment",
           "description": "@Prompt('Establishment Code','A','Establishment\\Establishment Code',mono,free,,Not_Persistent,,User:3)",
           "mandatory": "true"
         },
@@ -127,7 +127,7 @@
           "filterType": "autocomplete",
           "referenceType": "establishment",
           "reportFieldType": "string",
-          "display": "Establishment Code",
+          "display": "Establishment",
           "description": "@Prompt('Establishment Code','A','Establishment\\Establishment Code',mono,free,,Not_Persistent,,User:3)",
           "mandatory": "true"
         },
@@ -375,7 +375,7 @@
           "filterType": "autocomplete",
           "referenceType": "establishment",
           "reportFieldType": "string",
-          "display": "Establishment Code",
+          "display": "Establishment",
           "description": "@Prompt('Establishment Code','A','Establishment\\Establishment Code',mono,free,,Not_Persistent,,User:3)",
           "mandatory": "true"
         }
@@ -414,7 +414,7 @@
           "filterType": "autocomplete",
           "referenceType": "establishment",
           "reportFieldType": "string",
-          "display": "Establishment Code",
+          "display": "Establishment",
           "description": "@Prompt('Establishment Code','A','Establishment\\Establishment Code',mono,free,,Not_Persistent,,User:3)",
           "mandatory": "true"
         }
@@ -461,7 +461,7 @@
           "filterType": "autocomplete",
           "referenceType": "establishment",
           "reportFieldType": "string",
-          "display": "Establishment Code",
+          "display": "Establishment",
           "description": "@Prompt('Establishment Code','A','Establishment\\Establishment Code',mono,free,,Not_Persistent,,User:3)",
           "mandatory": "true"
         },
@@ -534,7 +534,7 @@
           "filterType": "autocomplete",
           "referenceType": "establishment",
           "reportFieldType": "string",
-          "display": "Establishment Code",
+          "display": "Establishment",
           "description": "@Prompt('Establishment Code','A','Establishment\\Establishment Code',mono,free,,Not_Persistent,,User:3)",
           "mandatory": "true"
         },
@@ -694,7 +694,7 @@
           "filterType": "autocomplete",
           "referenceType": "establishment",
           "reportFieldType": "string",
-          "display": "Establishment Code",
+          "display": "Establishment",
           "description": "@Prompt('Establishment Code','A','Establishment\\Establishment Code',mono,free,,Not_Persistent,,User:3)",
           "mandatory": "true"
         }

--- a/src/main/resources/test/definitions/prisons/orphanage/ors-social-visit-statistics.json
+++ b/src/main/resources/test/definitions/prisons/orphanage/ors-social-visit-statistics.json
@@ -25,7 +25,8 @@
         {
           "index": 0,
           "name": "establishment_code",
-          "filterType": "text",
+          "filterType": "autocomplete",
+          "referenceType": "establishment",
           "reportFieldType": "string",
           "display": "Establishment Code Where Visit Held",
           "description": "@prompt('Enter Establishment Code Where Visit Held','A','Visit History\\Establishment Code Where Visit Held',Multi,Free,Not_Persistent,,User:2)",

--- a/src/main/resources/test/definitions/prisons/orphanage/ors-summary-of-releases-and-taps.json
+++ b/src/main/resources/test/definitions/prisons/orphanage/ors-summary-of-releases-and-taps.json
@@ -25,7 +25,8 @@
         {
           "index": 0,
           "name": "establishment_code",
-          "filterType": "text",
+          "filterType": "autocomplete",
+          "referenceType": "establishment",
           "reportFieldType": "string",
           "display": "Establishment Code",
           "description": "@prompt('Establishment Code','A','Establishment\\Establishment Code',Mono,Free,Not_Persistent,,User:0)",
@@ -97,7 +98,8 @@
         {
           "index": 0,
           "name": "establishment_code",
-          "filterType": "text",
+          "filterType": "autocomplete",
+          "referenceType": "establishment",
           "reportFieldType": "string",
           "display": "Establishment Code",
           "description": "@prompt('Establishment Code','A','Establishment\\Establishment Code',Mono,Free,Not_Persistent,,User:0)",

--- a/src/main/resources/test/definitions/prisons/orphanage/ors-summary-of-releases-and-taps.json
+++ b/src/main/resources/test/definitions/prisons/orphanage/ors-summary-of-releases-and-taps.json
@@ -28,7 +28,7 @@
           "filterType": "autocomplete",
           "referenceType": "establishment",
           "reportFieldType": "string",
-          "display": "Establishment Code",
+          "display": "Establishment",
           "description": "@prompt('Establishment Code','A','Establishment\\Establishment Code',Mono,Free,Not_Persistent,,User:0)",
           "mandatory": "true"
         },
@@ -101,7 +101,7 @@
           "filterType": "autocomplete",
           "referenceType": "establishment",
           "reportFieldType": "string",
-          "display": "Establishment Code",
+          "display": "Establishment",
           "description": "@prompt('Establishment Code','A','Establishment\\Establishment Code',Mono,Free,Not_Persistent,,User:0)",
           "mandatory": "true"
         },

--- a/src/main/resources/test/definitions/prisons/orphanage/ors-temporary-absence-and-home-leave-return-dates.json
+++ b/src/main/resources/test/definitions/prisons/orphanage/ors-temporary-absence-and-home-leave-return-dates.json
@@ -46,7 +46,7 @@
           "filterType": "autocomplete",
           "referenceType": "establishment",
           "reportFieldType": "string",
-          "display": "Establishment Code",
+          "display": "Establishment",
           "description": "@prompt('Establishment Code','A','TAP Return\\Returning To Establishment Code',Mono,Free,Not_Persistent,,User:2)",
           "mandatory": "true"
         }

--- a/src/main/resources/test/definitions/prisons/orphanage/ors-temporary-absence-and-home-leave-return-dates.json
+++ b/src/main/resources/test/definitions/prisons/orphanage/ors-temporary-absence-and-home-leave-return-dates.json
@@ -43,7 +43,8 @@
         {
           "index": 2,
           "name": "establishment_code",
-          "filterType": "text",
+          "filterType": "autocomplete",
+          "referenceType": "establishment",
           "reportFieldType": "string",
           "display": "Establishment Code",
           "description": "@prompt('Establishment Code','A','TAP Return\\Returning To Establishment Code',Mono,Free,Not_Persistent,,User:2)",

--- a/src/main/resources/test/definitions/prisons/orphanage/ors-transfer-holds-report.json
+++ b/src/main/resources/test/definitions/prisons/orphanage/ors-transfer-holds-report.json
@@ -25,7 +25,8 @@
         {
           "index": 0,
           "name": "establishment_code",
-          "filterType": "text",
+          "filterType": "autocomplete",
+          "referenceType": "establishment",
           "reportFieldType": "string",
           "display": "Establishment Code",
           "description": "@Prompt('Establishment Code','A','Establishment\\Establishment Code',mono,free,,Not_Persistent,,User:3)",
@@ -34,7 +35,8 @@
         {
           "index": 1,
           "name": "wing",
-          "filterType": "text",
+          "filterType": "autocomplete",
+          "referenceType": "wing",
           "reportFieldType": "string",
           "display": "Wing (All for all)",
           "description": "@Prompt('Wing (All for all)','A','Cell\\Location LOV',multi,free,,Not_Persistent,,User:4)",

--- a/src/main/resources/test/definitions/prisons/orphanage/ors-transfer-holds-report.json
+++ b/src/main/resources/test/definitions/prisons/orphanage/ors-transfer-holds-report.json
@@ -28,7 +28,7 @@
           "filterType": "autocomplete",
           "referenceType": "establishment",
           "reportFieldType": "string",
-          "display": "Establishment Code",
+          "display": "Establishment",
           "description": "@Prompt('Establishment Code','A','Establishment\\Establishment Code',mono,free,,Not_Persistent,,User:3)",
           "mandatory": "true"
         },

--- a/src/main/resources/test/definitions/prisons/orphanage/ors-transfers-in-and-out-of-establishments.json
+++ b/src/main/resources/test/definitions/prisons/orphanage/ors-transfers-in-and-out-of-establishments.json
@@ -28,7 +28,7 @@
           "filterType": "autocomplete",
           "referenceType": "establishment",
           "reportFieldType": "string",
-          "display": "Establishment Code",
+          "display": "Establishment",
           "description": "@prompt('Establishment','A','Establishment\\Establishment',Mono,Free,Not_Persistent,,User:0)",
           "mandatory": "true"
         },

--- a/src/main/resources/test/definitions/prisons/orphanage/ors-transfers-in-and-out-of-establishments.json
+++ b/src/main/resources/test/definitions/prisons/orphanage/ors-transfers-in-and-out-of-establishments.json
@@ -25,7 +25,8 @@
         {
           "index": 0,
           "name": "establishment_code",
-          "filterType": "text",
+          "filterType": "autocomplete",
+          "referenceType": "establishment",
           "reportFieldType": "string",
           "display": "Establishment Code",
           "description": "@prompt('Establishment','A','Establishment\\Establishment',Mono,Free,Not_Persistent,,User:0)",

--- a/src/main/resources/test/definitions/prisons/orphanage/ors-unlock-list.json
+++ b/src/main/resources/test/definitions/prisons/orphanage/ors-unlock-list.json
@@ -25,7 +25,8 @@
         {
           "index": 0,
           "name": "establishment_code",
-          "filterType": "text",
+          "filterType": "autocomplete",
+          "referenceType": "establishment",
           "reportFieldType": "string",
           "display": "Establishment Code",
           "description": "@Prompt('Establishment Code','A','Establishment\\Establishment Code',mono,free,,Not_Persistent,,User:3)",
@@ -34,7 +35,8 @@
         {
           "index": 1,
           "name": "wing",
-          "filterType": "text",
+          "filterType": "autocomplete",
+          "referenceType": "wing",
           "reportFieldType": "string",
           "display": "Wing (All for all)",
           "description": "@Prompt('Wing (All for all)','A','Cell\\Level 1 Living Unit LOV',multi,free,,Not_Persistent,,User:4)",

--- a/src/main/resources/test/definitions/prisons/orphanage/ors-unlock-list.json
+++ b/src/main/resources/test/definitions/prisons/orphanage/ors-unlock-list.json
@@ -28,7 +28,7 @@
           "filterType": "autocomplete",
           "referenceType": "establishment",
           "reportFieldType": "string",
-          "display": "Establishment Code",
+          "display": "Establishment",
           "description": "@Prompt('Establishment Code','A','Establishment\\Establishment Code',mono,free,,Not_Persistent,,User:3)",
           "mandatory": "true"
         },

--- a/src/main/resources/test/definitions/prisons/orphanage/ors-view-diary-for-a-day.json
+++ b/src/main/resources/test/definitions/prisons/orphanage/ors-view-diary-for-a-day.json
@@ -25,7 +25,8 @@
         {
           "index": 0,
           "name": "establishment_code",
-          "filterType": "text",
+          "filterType": "autocomplete",
+          "referenceType": "establishment",
           "reportFieldType": "string",
           "display": "Establishment Code",
           "description": "@Prompt('Establishment Code','A','Establishment\\Establishment Code',mono,free,,Not_Persistent,,User:3)",
@@ -34,7 +35,8 @@
         {
           "index": 1,
           "name": "wing",
-          "filterType": "text",
+          "filterType": "autocomplete",
+          "referenceType": "wing",
           "reportFieldType": "string",
           "display": "Wing (All for all)",
           "description": "@Prompt('Wing (All for all)','A','Cell\\Location LOV',multi,free,,Not_Persistent,,User:4)",

--- a/src/main/resources/test/definitions/prisons/orphanage/ors-view-diary-for-a-day.json
+++ b/src/main/resources/test/definitions/prisons/orphanage/ors-view-diary-for-a-day.json
@@ -28,7 +28,7 @@
           "filterType": "autocomplete",
           "referenceType": "establishment",
           "reportFieldType": "string",
-          "display": "Establishment Code",
+          "display": "Establishment",
           "description": "@Prompt('Establishment Code','A','Establishment\\Establishment Code',mono,free,,Not_Persistent,,User:3)",
           "mandatory": "true"
         },

--- a/src/main/resources/test/definitions/prisons/orphanage/ors-visit-history-for-a-prisoner.json
+++ b/src/main/resources/test/definitions/prisons/orphanage/ors-visit-history-for-a-prisoner.json
@@ -37,7 +37,7 @@
           "filterType": "autocomplete",
           "referenceType": "establishment",
           "reportFieldType": "string",
-          "display": "Establishment Code",
+          "display": "Establishment",
           "description": "@Prompt('Establishment Code','A','Establishment\\Establishment Code',mono,free,,Not_Persistent,,User:3)",
           "mandatory": "true"
         }

--- a/src/main/resources/test/definitions/prisons/orphanage/ors-visit-history-for-a-prisoner.json
+++ b/src/main/resources/test/definitions/prisons/orphanage/ors-visit-history-for-a-prisoner.json
@@ -34,7 +34,8 @@
         {
           "index": 1,
           "name": "establishment_code",
-          "filterType": "text",
+          "filterType": "autocomplete",
+          "referenceType": "establishment",
           "reportFieldType": "string",
           "display": "Establishment Code",
           "description": "@Prompt('Establishment Code','A','Establishment\\Establishment Code',mono,free,,Not_Persistent,,User:3)",

--- a/src/main/resources/test/definitions/prisons/orphanage/ors-visit-history-for-an-establishment.json
+++ b/src/main/resources/test/definitions/prisons/orphanage/ors-visit-history-for-an-establishment.json
@@ -28,7 +28,7 @@
           "filterType": "autocomplete",
           "referenceType": "establishment",
           "reportFieldType": "string",
-          "display": "Establishment Code",
+          "display": "Establishment",
           "description": "@prompt('Establishment Code','A','Visit History\\Establishment Code Where Visit Held',Mono,Free,Not_Persistent,,User:2)",
           "mandatory": "true"
         },
@@ -205,7 +205,7 @@
           "filterType": "autocomplete",
           "referenceType": "establishment",
           "reportFieldType": "string",
-          "display": "Establishment Code",
+          "display": "Establishment",
           "description": "@prompt('Establishment Code','A','Visit History\\Establishment Code Where Visit Held',Mono,Free,Not_Persistent,,User:2)",
           "mandatory": "true"
         },

--- a/src/main/resources/test/definitions/prisons/orphanage/ors-visit-history-for-an-establishment.json
+++ b/src/main/resources/test/definitions/prisons/orphanage/ors-visit-history-for-an-establishment.json
@@ -25,7 +25,8 @@
         {
           "index": 0,
           "name": "establishment_code",
-          "filterType": "text",
+          "filterType": "autocomplete",
+          "referenceType": "establishment",
           "reportFieldType": "string",
           "display": "Establishment Code",
           "description": "@prompt('Establishment Code','A','Visit History\\Establishment Code Where Visit Held',Mono,Free,Not_Persistent,,User:2)",
@@ -201,7 +202,8 @@
         {
           "index": 0,
           "name": "establishment_code",
-          "filterType": "text",
+          "filterType": "autocomplete",
+          "referenceType": "establishment",
           "reportFieldType": "string",
           "display": "Establishment Code",
           "description": "@prompt('Establishment Code','A','Visit History\\Establishment Code Where Visit Held',Mono,Free,Not_Persistent,,User:2)",

--- a/src/main/resources/test/definitions/prisons/orphanage/ors-visit-orders-remaining.json
+++ b/src/main/resources/test/definitions/prisons/orphanage/ors-visit-orders-remaining.json
@@ -25,7 +25,8 @@
         {
           "index": 0,
           "name": "establishment_code",
-          "filterType": "text",
+          "filterType": "autocomplete",
+          "referenceType": "establishment",
           "reportFieldType": "string",
           "display": "Establishment Code",
           "description": "@Prompt('Establishment Code','A','Establishment\\Establishment Code',mono,free,,Not_Persistent,,User:3)",

--- a/src/main/resources/test/definitions/prisons/orphanage/ors-visit-orders-remaining.json
+++ b/src/main/resources/test/definitions/prisons/orphanage/ors-visit-orders-remaining.json
@@ -28,7 +28,7 @@
           "filterType": "autocomplete",
           "referenceType": "establishment",
           "reportFieldType": "string",
-          "display": "Establishment Code",
+          "display": "Establishment",
           "description": "@Prompt('Establishment Code','A','Establishment\\Establishment Code',mono,free,,Not_Persistent,,User:3)",
           "mandatory": "true"
         }

--- a/src/main/resources/test/definitions/prisons/orphanage/ors-visits-booked-for-a-date-range-in-the-future.json
+++ b/src/main/resources/test/definitions/prisons/orphanage/ors-visits-booked-for-a-date-range-in-the-future.json
@@ -25,7 +25,8 @@
         {
           "index": 0,
           "name": "establishment_code",
-          "filterType": "text",
+          "filterType": "autocomplete",
+          "referenceType": "establishment",
           "reportFieldType": "string",
           "display": "Establishment Code",
           "description": "@Prompt('Establishment Code','A','Establishment\\Establishment Code',mono,free,,Not_Persistent,,User:3)",

--- a/src/main/resources/test/definitions/prisons/orphanage/ors-visits-booked-for-a-date-range-in-the-future.json
+++ b/src/main/resources/test/definitions/prisons/orphanage/ors-visits-booked-for-a-date-range-in-the-future.json
@@ -28,7 +28,7 @@
           "filterType": "autocomplete",
           "referenceType": "establishment",
           "reportFieldType": "string",
-          "display": "Establishment Code",
+          "display": "Establishment",
           "description": "@Prompt('Establishment Code','A','Establishment\\Establishment Code',mono,free,,Not_Persistent,,User:3)",
           "mandatory": "true"
         },

--- a/src/main/resources/test/definitions/prisons/orphanage/ors-visits-landing-list.json
+++ b/src/main/resources/test/definitions/prisons/orphanage/ors-visits-landing-list.json
@@ -25,7 +25,8 @@
         {
           "index": 0,
           "name": "establishment_code",
-          "filterType": "text",
+          "filterType": "autocomplete",
+          "referenceType": "establishment",
           "reportFieldType": "string",
           "display": "Establishment Code",
           "description": "@Prompt('Establishment Code','A','Establishment\\Establishment Code',mono,free,,Not_Persistent,,User:3)",

--- a/src/main/resources/test/definitions/prisons/orphanage/ors-visits-landing-list.json
+++ b/src/main/resources/test/definitions/prisons/orphanage/ors-visits-landing-list.json
@@ -28,7 +28,7 @@
           "filterType": "autocomplete",
           "referenceType": "establishment",
           "reportFieldType": "string",
-          "display": "Establishment Code",
+          "display": "Establishment",
           "description": "@Prompt('Establishment Code','A','Establishment\\Establishment Code',mono,free,,Not_Persistent,,User:3)",
           "mandatory": "true"
         },

--- a/src/main/resources/test/definitions/prisons/orphanage/ors-visits-list.json
+++ b/src/main/resources/test/definitions/prisons/orphanage/ors-visits-list.json
@@ -25,7 +25,8 @@
         {
           "index": 0,
           "name": "establishment_code",
-          "filterType": "text",
+          "filterType": "autocomplete",
+          "referenceType": "establishment",
           "reportFieldType": "string",
           "display": "Establishment Code",
           "description": "@Prompt('Establishment Code','A','Establishment\\Establishment Code',mono,free,,Not_Persistent,,User:3)",
@@ -34,7 +35,8 @@
         {
           "index": 1,
           "name": "wing",
-          "filterType": "text",
+          "filterType": "autocomplete",
+          "referenceType": "wing",
           "reportFieldType": "string",
           "display": "Wing (All for all)",
           "description": "@Prompt('Wing (All for all)','A','Cell\\Level 1 Living Unit LOV',multi,free,,Not_Persistent,,User:4)",
@@ -233,7 +235,8 @@
         {
           "index": 0,
           "name": "establishment_code",
-          "filterType": "text",
+          "filterType": "autocomplete",
+          "referenceType": "establishment",
           "reportFieldType": "string",
           "display": "Establishment Code",
           "description": "@Prompt('Establishment Code','A','Establishment\\Establishment Code',mono,free,,Not_Persistent,,User:3)",
@@ -242,7 +245,8 @@
         {
           "index": 1,
           "name": "wing",
-          "filterType": "text",
+          "filterType": "autocomplete",
+          "referenceType": "wing",
           "reportFieldType": "string",
           "display": "Wing (All for all)",
           "description": "@Prompt('Wing (All for all)','A','Cell\\Level 1 Living Unit LOV',multi,free,,Not_Persistent,,User:4)",

--- a/src/main/resources/test/definitions/prisons/orphanage/ors-visits-list.json
+++ b/src/main/resources/test/definitions/prisons/orphanage/ors-visits-list.json
@@ -28,7 +28,7 @@
           "filterType": "autocomplete",
           "referenceType": "establishment",
           "reportFieldType": "string",
-          "display": "Establishment Code",
+          "display": "Establishment",
           "description": "@Prompt('Establishment Code','A','Establishment\\Establishment Code',mono,free,,Not_Persistent,,User:3)",
           "mandatory": "true"
         },
@@ -238,7 +238,7 @@
           "filterType": "autocomplete",
           "referenceType": "establishment",
           "reportFieldType": "string",
-          "display": "Establishment Code",
+          "display": "Establishment",
           "description": "@Prompt('Establishment Code','A','Establishment\\Establishment Code',mono,free,,Not_Persistent,,User:3)",
           "mandatory": "true"
         },


### PR DESCRIPTION
Changes include:
- Updated the Dev and Test DPDs by adding a "referenceType" of "establishment" or "wing" for establishment_code and wing parameters respectively.
- Changed the Display value from Establishment Code to Establishment since now the list of establishments appears in the dropdown when the user types either the code or the name of the establishment in the autocomplete input.
- Changed the filterType from "text" to "autocomplete".