### PR TITLE
DPR2-1837 update dashboard definitions

### DIFF
--- a/dpd/dev/definitions/prisons/orphanage/data-quality-metrics-filters-testing.json
+++ b/dpd/dev/definitions/prisons/orphanage/data-quality-metrics-filters-testing.json
@@ -1,7 +1,7 @@
 {
   "id" : "data-quality-metrics",
-  "name" : "Measures missing data",
-  "description" : "Dashboard to show missing data quality measures",
+  "name" : "measure missing data",
+  "description" : "Dashboard to show missing data quality measure",
   "metadata" : {
     "author" : "Zahoor",
     "version" : "1.2.3",
@@ -91,30 +91,30 @@
       }
     }
   ],
-  "dashboards" : [
+  "dashboard" : [
     {
       "id" : "data-quality-dashboard-test",
       "name" : "Data quality dashboard",
       "description" : "Data quality dashboard",
       "dataset" : "data-quality-dataset",
-      "sections" : [
+      "section" : [
         {
           "id" : "missing-ethnicity-section",
           "display" : "Missing ethnicity",
           "description" : "Number of prisoner with missing or present ethnicity data",
-          "visualisations" : [
+          "visualisation" : [
             {
               "id": "missing-ethnicity-metric-bar-visualisation",
               "type" : "bar",
               "display" : "Missing ethnicity",
-              "columns": {
-                "keys": [
+              "column": {
+                "key": [
                   {
                     "id": "$ref:establishment_id",
                     "display": "Establishmnent ID"
                   }
                 ],
-                "measures": [
+                "measure": [
                   {
                     "id": "$ref:has_ethnicity",
                     "display": "% of prisoners with ethnicity",
@@ -126,21 +126,21 @@
                     "unit" : "percentage"
                   }
                 ],
-                "expectNulls": false
+                "expectNull": false
               }
             },
             {
               "id": "missing-ethnicity-metric-doughnut-visualisation",
               "type" : "doughnut",
               "display" : "Missing ethnicity",
-              "columns": {
-                "keys": [
+              "column": {
+                "key": [
                   {
                     "id": "$ref:establishment_id",
                     "display": "Establishmnent ID"
                   }
                 ],
-                "measures": [
+                "measure": [
                   {
                     "id": "$ref:has_ethnicity",
                     "display": "% of prisoners with ethnicity",
@@ -152,7 +152,7 @@
                     "unit" : "percentage"
                   }
                 ],
-                "expectNulls": false
+                "expectNull": false
               }
             }
           ]
@@ -161,19 +161,19 @@
           "id" : "missing-nationality-section",
           "display" : "Missing nationality",
           "description" : "Number of prisoner with missing or present nationality data\",",
-          "visualisations" : [
+          "visualisation" : [
             {
               "id": "missing-nationality-metric-bar-visualisation",
               "type" : "bar",
               "display" : "Missing nationality",
-              "columns": {
-                "keys": [
+              "column": {
+                "key": [
                   {
                     "id": "$ref:establishment_id",
                     "display": "Establishmnent ID"
                   }
                 ],
-                "measures": [
+                "measure": [
                   {
                     "id": "$ref:has_nationality",
                     "display": "% of prisoners with nationality",
@@ -185,21 +185,21 @@
                     "unit" : "percentage"
                   }
                 ],
-                "expectNulls": false
+                "expectNull": false
               }
             },
             {
               "id": "missing-nationality-doughnut-visualisation",
               "type" : "doughnut",
               "display" : "Missing nationality",
-              "columns": {
-                "keys": [
+              "column": {
+                "key": [
                   {
                     "id": "$ref:establishment_id",
                     "display": "Establishmnent ID"
                   }
                 ],
-                "measures": [
+                "measure": [
                   {
                     "id" : "$ref:has_nationality",
                     "display" : "% of prisoners with nationality",
@@ -211,7 +211,7 @@
                     "unit" : "percentage"
                   }
                 ],
-                "expectNulls": false
+                "expectNull": false
               }
             }
           ]
@@ -220,19 +220,19 @@
           "id" : "missing-religion-section",
           "display" : "Missing religion",
           "description" : "Number of prisoner with missing or present religion data",
-          "visualisations" : [
+          "visualisation" : [
             {
               "id": "missing-religion-bar-visualisation",
               "type" : "bar",
               "display" : "Missing Religion",
-              "columns": {
-                "keys": [
+              "column": {
+                "key": [
                   {
                     "id": "$ref:establishment_id",
                     "display": "Establishmnent ID"
                   }
                 ],
-                "measures": [
+                "measure": [
                   {
                     "id": "$ref:has_religion",
                     "display": "% of prisoners with religion",
@@ -244,21 +244,21 @@
                     "unit" : "percentage"
                   }
                 ],
-                "expectNulls": false
+                "expectNull": false
               }
             },
             {
               "id": "missing-religion-doughnut-visualisation",
               "type" : "doughnut",
               "display" : "Missing religion",
-              "columns": {
-                "keys": [
+              "column": {
+                "key": [
                   {
                     "id": "$ref:establishment_id",
                     "display": "Establishment ID"
                   }
                 ],
-                "measures": [
+                "measure": [
                   {
                     "id" : "$ref:has_religion",
                     "display" : "% of prisoners with religion",
@@ -270,7 +270,7 @@
                     "unit" : "percentage"
                   }
                 ],
-                "expectNulls": false
+                "expectNull": false
               }
             }
           ]

--- a/dpd/dev/definitions/prisons/orphanage/ors-age-breakdown-report.json
+++ b/dpd/dev/definitions/prisons/orphanage/ors-age-breakdown-report.json
@@ -335,7 +335,7 @@
       }
     }
   ],
-  "dashboards": [
+  "dashboard": [
     {
       "id": "167078.RS",
       "name": "Summary",
@@ -344,26 +344,26 @@
       "version": "1.0.0",
       "render": "HTML",
       "dataset": "3377299/DP3",
-      "sections": [
+      "section": [
         {
           "id" : "167078.RS.1",
           "display" : "Title",
           "description" : "Description",
-          "visualisations" : [
+          "visualisation" : [
             {
               "id": "167078.RS.1.1",
               "type" : "list",
               "display" : "Table name",
-              "columns": {
-                "keys": [
+              "column": {
+                "key": [
                   {
                     "id": "$ref:OFFENDER_ID_DISPLAY",
                     "display": "Offender Id"
                   }
                 ],
-                "measures": [
+                "measure": [
                 ],
-                "expectNulls": false
+                "expectNull": false
               }
             }
           ]

--- a/dpd/preprod/definitions/prisons/orphanage/data-quality-metrics-filters-testing.json
+++ b/dpd/preprod/definitions/prisons/orphanage/data-quality-metrics-filters-testing.json
@@ -1,7 +1,7 @@
 {
   "id" : "data-quality-metrics",
-  "name" : "Measures missing data",
-  "description" : "Dashboard to show missing data quality measures",
+  "name" : "measure missing data",
+  "description" : "Dashboard to show missing data quality measure",
   "metadata" : {
     "author" : "Zahoor",
     "version" : "1.2.3",
@@ -91,30 +91,30 @@
       }
     }
   ],
-  "dashboards" : [
+  "dashboard" : [
     {
       "id" : "data-quality-dashboard-test",
       "name" : "Data quality dashboard",
       "description" : "Data quality dashboard",
       "dataset" : "data-quality-dataset",
-      "sections" : [
+      "section" : [
         {
           "id" : "missing-ethnicity-section",
           "display" : "Missing ethnicity",
           "description" : "Number of prisoner with missing or present ethnicity data",
-          "visualisations" : [
+          "visualisation" : [
             {
               "id": "missing-ethnicity-metric-bar-visualisation",
               "type" : "bar",
               "display" : "Missing ethnicity",
-              "columns": {
-                "keys": [
+              "column": {
+                "key": [
                   {
                     "id": "$ref:establishment_id",
                     "display": "Establishmnent ID"
                   }
                 ],
-                "measures": [
+                "measure": [
                   {
                     "id": "$ref:has_ethnicity",
                     "display": "% of prisoners with ethnicity",
@@ -126,21 +126,21 @@
                     "unit" : "percentage"
                   }
                 ],
-                "expectNulls": false
+                "expectNull": false
               }
             },
             {
               "id": "missing-ethnicity-metric-doughnut-visualisation",
               "type" : "doughnut",
               "display" : "Missing ethnicity",
-              "columns": {
-                "keys": [
+              "column": {
+                "key": [
                   {
                     "id": "$ref:establishment_id",
                     "display": "Establishmnent ID"
                   }
                 ],
-                "measures": [
+                "measure": [
                   {
                     "id": "$ref:has_ethnicity",
                     "display": "% of prisoners with ethnicity",
@@ -152,7 +152,7 @@
                     "unit" : "percentage"
                   }
                 ],
-                "expectNulls": false
+                "expectNull": false
               }
             }
           ]
@@ -161,19 +161,19 @@
           "id" : "missing-nationality-section",
           "display" : "Missing nationality",
           "description" : "Number of prisoner with missing or present nationality data\",",
-          "visualisations" : [
+          "visualisation" : [
             {
               "id": "missing-nationality-metric-bar-visualisation",
               "type" : "bar",
               "display" : "Missing nationality",
-              "columns": {
-                "keys": [
+              "column": {
+                "key": [
                   {
                     "id": "$ref:establishment_id",
                     "display": "Establishmnent ID"
                   }
                 ],
-                "measures": [
+                "measure": [
                   {
                     "id": "$ref:has_nationality",
                     "display": "% of prisoners with nationality",
@@ -185,21 +185,21 @@
                     "unit" : "percentage"
                   }
                 ],
-                "expectNulls": false
+                "expectNull": false
               }
             },
             {
               "id": "missing-nationality-doughnut-visualisation",
               "type" : "doughnut",
               "display" : "Missing nationality",
-              "columns": {
-                "keys": [
+              "column": {
+                "key": [
                   {
                     "id": "$ref:establishment_id",
                     "display": "Establishmnent ID"
                   }
                 ],
-                "measures": [
+                "measure": [
                   {
                     "id" : "$ref:has_nationality",
                     "display" : "% of prisoners with nationality",
@@ -211,7 +211,7 @@
                     "unit" : "percentage"
                   }
                 ],
-                "expectNulls": false
+                "expectNull": false
               }
             }
           ]
@@ -220,19 +220,19 @@
           "id" : "missing-religion-section",
           "display" : "Missing religion",
           "description" : "Number of prisoner with missing or present religion data",
-          "visualisations" : [
+          "visualisation" : [
             {
               "id": "missing-religion-bar-visualisation",
               "type" : "bar",
               "display" : "Missing Religion",
-              "columns": {
-                "keys": [
+              "column": {
+                "key": [
                   {
                     "id": "$ref:establishment_id",
                     "display": "Establishmnent ID"
                   }
                 ],
-                "measures": [
+                "measure": [
                   {
                     "id": "$ref:has_religion",
                     "display": "% of prisoners with religion",
@@ -244,21 +244,21 @@
                     "unit" : "percentage"
                   }
                 ],
-                "expectNulls": false
+                "expectNull": false
               }
             },
             {
               "id": "missing-religion-doughnut-visualisation",
               "type" : "doughnut",
               "display" : "Missing religion",
-              "columns": {
-                "keys": [
+              "column": {
+                "key": [
                   {
                     "id": "$ref:establishment_id",
                     "display": "Establishment ID"
                   }
                 ],
-                "measures": [
+                "measure": [
                   {
                     "id" : "$ref:has_religion",
                     "display" : "% of prisoners with religion",
@@ -270,7 +270,7 @@
                     "unit" : "percentage"
                   }
                 ],
-                "expectNulls": false
+                "expectNull": false
               }
             }
           ]

--- a/dpd/test/definitions/prisons/orphanage/data-quality-metrics-filters-testing.json
+++ b/dpd/test/definitions/prisons/orphanage/data-quality-metrics-filters-testing.json
@@ -1,7 +1,7 @@
 {
   "id" : "data-quality-metrics",
-  "name" : "Measures missing data",
-  "description" : "Dashboard to show missing data quality measures",
+  "name" : "measure missing data",
+  "description" : "Dashboard to show missing data quality measure",
   "metadata" : {
     "author" : "Zahoor",
     "version" : "1.2.3",
@@ -91,30 +91,30 @@
       }
     }
   ],
-  "dashboards" : [
+  "dashboard" : [
     {
       "id" : "data-quality-dashboard-test",
       "name" : "Data quality dashboard",
       "description" : "Data quality dashboard",
       "dataset" : "data-quality-dataset",
-      "sections" : [
+      "section" : [
         {
           "id" : "missing-ethnicity-section",
           "display" : "Missing ethnicity",
           "description" : "Number of prisoner with missing or present ethnicity data",
-          "visualisations" : [
+          "visualisation" : [
             {
               "id": "missing-ethnicity-metric-bar-visualisation",
               "type" : "bar",
               "display" : "Missing ethnicity",
-              "columns": {
-                "keys": [
+              "column": {
+                "key": [
                   {
                     "id": "$ref:establishment_id",
                     "display": "Establishmnent ID"
                   }
                 ],
-                "measures": [
+                "measure": [
                   {
                     "id": "$ref:has_ethnicity",
                     "display": "% of prisoners with ethnicity",
@@ -126,21 +126,21 @@
                     "unit" : "percentage"
                   }
                 ],
-                "expectNulls": false
+                "expectNull": false
               }
             },
             {
               "id": "missing-ethnicity-metric-doughnut-visualisation",
               "type" : "doughnut",
               "display" : "Missing ethnicity",
-              "columns": {
-                "keys": [
+              "column": {
+                "key": [
                   {
                     "id": "$ref:establishment_id",
                     "display": "Establishmnent ID"
                   }
                 ],
-                "measures": [
+                "measure": [
                   {
                     "id": "$ref:has_ethnicity",
                     "display": "% of prisoners with ethnicity",
@@ -152,7 +152,7 @@
                     "unit" : "percentage"
                   }
                 ],
-                "expectNulls": false
+                "expectNull": false
               }
             }
           ]
@@ -161,19 +161,19 @@
           "id" : "missing-nationality-section",
           "display" : "Missing nationality",
           "description" : "Number of prisoner with missing or present nationality data\",",
-          "visualisations" : [
+          "visualisation" : [
             {
               "id": "missing-nationality-metric-bar-visualisation",
               "type" : "bar",
               "display" : "Missing nationality",
-              "columns": {
-                "keys": [
+              "column": {
+                "key": [
                   {
                     "id": "$ref:establishment_id",
                     "display": "Establishmnent ID"
                   }
                 ],
-                "measures": [
+                "measure": [
                   {
                     "id": "$ref:has_nationality",
                     "display": "% of prisoners with nationality",
@@ -185,21 +185,21 @@
                     "unit" : "percentage"
                   }
                 ],
-                "expectNulls": false
+                "expectNull": false
               }
             },
             {
               "id": "missing-nationality-doughnut-visualisation",
               "type" : "doughnut",
               "display" : "Missing nationality",
-              "columns": {
-                "keys": [
+              "column": {
+                "key": [
                   {
                     "id": "$ref:establishment_id",
                     "display": "Establishmnent ID"
                   }
                 ],
-                "measures": [
+                "measure": [
                   {
                     "id" : "$ref:has_nationality",
                     "display" : "% of prisoners with nationality",
@@ -211,7 +211,7 @@
                     "unit" : "percentage"
                   }
                 ],
-                "expectNulls": false
+                "expectNull": false
               }
             }
           ]
@@ -220,19 +220,19 @@
           "id" : "missing-religion-section",
           "display" : "Missing religion",
           "description" : "Number of prisoner with missing or present religion data",
-          "visualisations" : [
+          "visualisation" : [
             {
               "id": "missing-religion-bar-visualisation",
               "type" : "bar",
               "display" : "Missing Religion",
-              "columns": {
-                "keys": [
+              "column": {
+                "key": [
                   {
                     "id": "$ref:establishment_id",
                     "display": "Establishmnent ID"
                   }
                 ],
-                "measures": [
+                "measure": [
                   {
                     "id": "$ref:has_religion",
                     "display": "% of prisoners with religion",
@@ -244,21 +244,21 @@
                     "unit" : "percentage"
                   }
                 ],
-                "expectNulls": false
+                "expectNull": false
               }
             },
             {
               "id": "missing-religion-doughnut-visualisation",
               "type" : "doughnut",
               "display" : "Missing religion",
-              "columns": {
-                "keys": [
+              "column": {
+                "key": [
                   {
                     "id": "$ref:establishment_id",
                     "display": "Establishment ID"
                   }
                 ],
-                "measures": [
+                "measure": [
                   {
                     "id" : "$ref:has_religion",
                     "display" : "% of prisoners with religion",
@@ -270,7 +270,7 @@
                     "unit" : "percentage"
                   }
                 ],
-                "expectNulls": false
+                "expectNull": false
               }
             }
           ]


### PR DESCRIPTION
Renamed dashboard fields which were defining collections from plural to singular to comply with existing naming conventions in DPDs.
Made dashboard description optional