### PR TITLE
DPR2-1952 fix by location summary

### DIFF
--- a/dpd/dev/definitions/prisons/clean/ors-prisoner-iep-levels.json
+++ b/dpd/dev/definitions/prisons/clean/ors-prisoner-iep-levels.json
@@ -211,7 +211,7 @@
       "id": "prisoner-distinct-count-per-location-and-iep-level",
       "name": "Distinct prisoner count",
       "datasource": "redshift",
-      "query": "select t1.UNIT_CODE_1, t1.UNIT_CODE_1 as LOCATION, t1.IEP_LEVEL, t1.PRISONER_COUNT, ROUND(PRISONER_COUNT * 100.0/t2.total_count, 2) as percentage from (select UNIT_CODE_1, IEP_LEVEL, count(distinct OFFENDER_ID_DISPLAY) as PRISONER_COUNT from ${tableId} GROUP BY UNIT_CODE_1, IEP_LEVEL) as t1, (SELECT COUNT(distinct OFFENDER_ID_DISPLAY) as total_count FROM ${tableId}) as t2",
+      "query": "WITH t1_ AS (select UNIT_CODE_1, IEP_LEVEL, count(distinct OFFENDER_ID_DISPLAY) as PRISONER_COUNT from ${tableId} GROUP BY UNIT_CODE_1, IEP_LEVEL) select t1_.UNIT_CODE_1, t1_.UNIT_CODE_1 as LOCATION, t1_.IEP_LEVEL, t1_.PRISONER_COUNT, ROUND(PRISONER_COUNT * 100.0/t2.TOTAL_COUNT, 2) as percentage from t1_ JOIN (select UNIT_CODE_1, SUM(PRISONER_COUNT) as TOTAL_COUNT FROM t1_ GROUP BY UNIT_CODE_1) as t2 ON t1_.UNIT_CODE_1 = t2.UNIT_CODE_1",
       "schema": {
         "field": [
           {
@@ -906,7 +906,7 @@
         },
         {
           "id": "prisoner-total-row-count-per-location-and-iep-level",
-          "template": "section-footer",
+          "template": "section-header",
           "dataset": "$ref:prisoner-total-row-count-per-location-and-iep-level"
         }
       ],


### PR DESCRIPTION
These changes fix the "By Location" summary section to calculate the percentage in the same way the NART report displays it. 
Previously it was being calculated as a percentage of the total count of all results of all wings. 
Now it is calculated as a percentage of the total count of each Wing section. 