### PR TITLE
DPR2-2721 added test report to test the pipeline

### DIFF
--- a/dpd/dev/definitions/prisons/orphanage/test-to-be-deleted-ors-a-and-o-contingency-report.json
+++ b/dpd/dev/definitions/prisons/orphanage/test-to-be-deleted-ors-a-and-o-contingency-report.json
@@ -1,0 +1,422 @@
+{
+  "id": "testReportToBeDeleted",
+  "name": "This is a test report to confirm the DPD publication pipeline works",
+  "description": "This is a test report to confirm the DPD publication  pipeline works",
+  "metadata": {
+    "version": "1.0.0",
+    "tags": ["NAT0015", "A and O extract"]
+  },
+  "datasource": [
+    {
+      "id": "nomis",
+      "name": "NOMIS",
+      "database": "DIGITAL_PRISON_REPORTING",
+      "catalog": "nomis"
+    }
+  ],
+  "dataset": [
+    {
+      "id": "3376286/DP0",
+      "name": "Offender",
+      "description": "OR - Sentence",
+      "datasource": "nomis",
+      "query": "DP7_ AS (SELECT DISTINCT AT_OFFENDER.OFFENDER_ID_DISPLAY, COALESCE( AT_EXT_MOV_FROM_AGY.DESCRIPTION, AT_FROM_CITY_CODES.DESCRIPTION, AT_FROM_ADDRESS_ATTENDED.STREET || ' ' || AT_FROM_ADDRESS_ATTENDED.LOCALITY || ' ' || AT_FROM_ADDRESS_ATTENDED.POSTAL_CODE ), COALESCE( AT_EXT_MOV_TO_AGY.DESCRIPTION, AT_TO_CITY_CODES.DESCRIPTION, AT_TO_ADDRESS_ATTENDED.STREET || ' ' || AT_TO_ADDRESS_ATTENDED.LOCALITY || ' ' || AT_TO_ADDRESS_ATTENDED.POSTAL_CODE ), AT_OFFENDER_EXTERNAL_MOVEMENTS.FROM_AGY_LOC_ID, AT_OFFENDER_EXTERNAL_MOVEMENTS.TO_AGY_LOC_ID, AT_OFFENDER_EXTERNAL_MOVEMENTS.MOVEMENT_SEQ FROM OMS_OWNER.OFFENDERS AT_OFFENDER, OMS_OWNER.REFERENCE_CODES AT_FROM_CITY_CODES, OMS_OWNER.REFERENCE_CODES AT_TO_CITY_CODES, OMS_OWNER.OFFENDER_BOOKINGS AT_OFFENDER_BOOKING, OMS_OWNER.AGENCY_LOCATIONS AT_EXT_MOV_FROM_AGY, OMS_OWNER.AGENCY_LOCATIONS AT_EXT_MOV_TO_AGY, OMS_OWNER.AGENCY_LOCATIONS AT_OFFENDERS_LOCATIONS, OMS_OWNER.OFFENDER_EXTERNAL_MOVEMENTS AT_OFFENDER_EXTERNAL_MOVEMENTS, OMS_OWNER.CASELOAD_AGENCY_LOCATIONS AT_CASELOAD_LOCATIONS, ADDRESSES AT_FROM_ADDRESS_ATTENDED, ADDRESSES AT_TO_ADDRESS_ATTENDED, USER_ACCESSIBLE_CASELOADS, ( /* SELECT OFFENDER_BOOK_ID, max(MOVEMENT_SEQ) AS MOVEMENT_SEQ FROM OMS_OWNER.OFFENDER_EXTERNAL_MOVEMENTS GROUP BY OFFENDER_BOOK_ID */ SELECT OFFENDER_BOOK_ID, MOVEMENT_SEQ, MAX(MOVEMENT_TIME) over (partition by offender_book_id) AS MOVEMENT_TIME FROM OMS_OWNER.OFFENDER_EXTERNAL_MOVEMENTS WHERE ACTIVE_FLAG = 'Y' ) DT_LATEST_EXTERNAL_MOVEMENT WHERE ( DT_LATEST_EXTERNAL_MOVEMENT.OFFENDER_BOOK_ID = AT_OFFENDER_EXTERNAL_MOVEMENTS.OFFENDER_BOOK_ID and DT_LATEST_EXTERNAL_MOVEMENT.MOVEMENT_SEQ = AT_OFFENDER_EXTERNAL_MOVEMENTS.MOVEMENT_SEQ ) AND ( AT_OFFENDER.OFFENDER_ID = AT_OFFENDER_BOOKING.OFFENDER_ID ) AND ( AT_OFFENDER_BOOKING.OFFENDER_BOOK_ID = AT_OFFENDER_EXTERNAL_MOVEMENTS.OFFENDER_BOOK_ID(+) ) AND ( AT_OFFENDERS_LOCATIONS.AGENCY_LOCATION_TYPE = 'INST' ) AND ( USER_ACCESSIBLE_CASELOADS.USERNAME = (SELECT username FROM context_) ) AND ( AT_OFFENDERS_LOCATIONS.AGY_LOC_ID = USER_ACCESSIBLE_CASELOADS.CASELOAD_ID ) AND ( AT_CASELOAD_LOCATIONS.AGY_LOC_ID = AT_OFFENDER_BOOKING.AGY_LOC_ID ) AND ( AT_CASELOAD_LOCATIONS.AGY_LOC_ID = AT_OFFENDERS_LOCATIONS.AGY_LOC_ID(+) ) AND ( AT_CASELOAD_LOCATIONS.AGY_LOC_ID NOT IN ('OUT', 'TRN') AND AT_CASELOAD_LOCATIONS.CASELOAD_ID NOT IN ('ADMINC', 'CADM_I', 'MULTI') ) AND ( AT_OFFENDER_EXTERNAL_MOVEMENTS.TO_AGY_LOC_ID = AT_EXT_MOV_TO_AGY.AGY_LOC_ID(+) ) AND ( AT_OFFENDER_EXTERNAL_MOVEMENTS.FROM_AGY_LOC_ID = AT_EXT_MOV_FROM_AGY.AGY_LOC_ID(+) ) AND ( AT_OFFENDER_EXTERNAL_MOVEMENTS.TO_CITY = AT_TO_CITY_CODES.CODE(+) ) AND ( AT_TO_CITY_CODES.DOMAIN = 'CITY' or AT_TO_CITY_CODES.DOMAIN is null ) AND ( AT_OFFENDER_EXTERNAL_MOVEMENTS.FROM_CITY = AT_FROM_CITY_CODES.CODE(+) ) AND ( AT_FROM_CITY_CODES.DOMAIN = 'CITY' or AT_FROM_CITY_CODES.DOMAIN is null ) AND ( AT_OFFENDER_EXTERNAL_MOVEMENTS.TO_ADDRESS_ID = AT_TO_ADDRESS_ATTENDED.ADDRESS_ID(+) ) AND ( AT_OFFENDER_EXTERNAL_MOVEMENTS.FROM_ADDRESS_ID = AT_FROM_ADDRESS_ATTENDED.ADDRESS_ID(+) ) AND ( (AT_OFFENDER_BOOKING.ACTIVE_FLAG = 'Y') AND ( AT_OFFENDERS_LOCATIONS.AGY_LOC_ID in ((SELECT establishment_code FROM prompt_)) or 'All' in ((SELECT establishment_code FROM prompt_)) ) AND AT_OFFENDERS_LOCATIONS.AGY_LOC_ID <> 'ZZGHI' AND ( USER_ACCESSIBLE_CASELOADS.USERNAME = (SELECT username FROM context_) ) AND ( DT_LATEST_EXTERNAL_MOVEMENT.OFFENDER_BOOK_ID = AT_OFFENDER_EXTERNAL_MOVEMENTS.OFFENDER_BOOK_ID and DT_LATEST_EXTERNAL_MOVEMENT.MOVEMENT_TIME = AT_OFFENDER_EXTERNAL_MOVEMENTS.MOVEMENT_TIME ) ) ), DP6_ AS ( SELECT DISTINCT AT_OFFENDER.OFFENDER_ID_DISPLAY, DT_OFFENDER_CSR_ASSESSMENT.ASSESSMENT_DATE, DT_OFFENDER_CSR_ASSESSMENT.APPROVED_RESULT, DT_OFFENDER_CSR_ASSESSMENT.CALC_SUP_LEVEL_TYPE, DT_OFFENDER_CSR_ASSESSMENT.NEXT_REVIEW_DATE, DT_OFFENDER_CSR_ASSESSMENT.OVERRIDED_SUP_LEVEL_TYPE FROM OMS_OWNER.OFFENDERS AT_OFFENDER, OMS_OWNER.OFFENDER_BOOKINGS AT_OFFENDER_BOOKING, OMS_OWNER.AGENCY_LOCATIONS AT_OFFENDERS_LOCATIONS, OMS_OWNER.CASELOAD_AGENCY_LOCATIONS AT_CASELOAD_LOCATIONS, ( SELECT offender_book_id, assessment_date, assessment_type, calc_sup_level_type, overrided_sup_level_type, approved_result, authority, next_review_date, assessment_seq, assess_status, score, coalesced_result, coalesced_result_description, row_seq_filter FROM ( SELECT v.*, rc.description coalesced_result_description FROM ( SELECT offender_book_id, assessment_date, assessment_type, calc_sup_level_type, overrided_sup_level_type, approved_result, authority, next_review_date, assessment_seq, assess_status, score, coalesced_result, CASE WHEN row_seq_filter_latest = 1 THEN 1 ELSE row_seq_filter_previous END row_seq_filter FROM ( SELECT offender_book_id, assessment_date, assessment_type, calc_sup_level_type, overrided_sup_level_type, approved_result, authority, next_review_date, assessment_seq, assess_status, score, coalesced_result, CASE WHEN row_seq_filter_latest = 1 AND assess_status = 'A' THEN 1 ELSE 0 END row_seq_filter_latest, COUNT( CASE WHEN row_seq_filter_previous = 1 AND assess_status <> 'A' THEN 1 END ) OVER (PARTITION BY offender_book_id) + row_seq_filter_previous row_seq_filter_previous FROM ( SELECT oa.offender_book_id, oa.assessment_date, a.description assessment_type, oa.calc_sup_level_type, oa.overrided_sup_level_type, oa.review_sup_level_type approved_result, oa.review_committe_code authority, oa.next_review_date, oa.assessment_seq, oa.assess_status, oa.score, COALESCE( oa.review_sup_level_type, oa.overrided_sup_level_type, oa.calc_sup_level_type ) coalesced_result, ROW_NUMBER() OVER ( PARTITION BY oa.offender_book_id ORDER BY oa.assess_status, oa.assessment_date DESC, oa.assessment_seq DESC ) row_seq_filter_latest, ROW_NUMBER() OVER ( PARTITION BY oa.offender_book_id ORDER BY oa.assessment_date DESC, oa.assessment_seq DESC ) row_seq_filter_previous FROM offender_assessments oa INNER JOIN assessments a ON a.assessment_id = oa.assessment_type_id AND a.assessment_class = 'TYPE' AND a.cell_sharing_alert_flag = 'Y' ) ) ) v LEFT OUTER JOIN reference_codes rc ON rc.code = v.coalesced_result AND rc.domain = 'SUP_LVL_TYPE' ) ) DT_OFFENDER_CSR_ASSESSMENT, USER_ACCESSIBLE_CASELOADS WHERE ( AT_OFFENDER.OFFENDER_ID = AT_OFFENDER_BOOKING.OFFENDER_ID ) AND ( AT_OFFENDERS_LOCATIONS.AGENCY_LOCATION_TYPE = 'INST' ) AND ( USER_ACCESSIBLE_CASELOADS.USERNAME = (SELECT username FROM context_) ) AND ( AT_OFFENDERS_LOCATIONS.AGY_LOC_ID = USER_ACCESSIBLE_CASELOADS.CASELOAD_ID ) AND ( AT_CASELOAD_LOCATIONS.AGY_LOC_ID = AT_OFFENDER_BOOKING.AGY_LOC_ID ) AND ( AT_CASELOAD_LOCATIONS.AGY_LOC_ID = AT_OFFENDERS_LOCATIONS.AGY_LOC_ID(+) ) AND ( AT_CASELOAD_LOCATIONS.AGY_LOC_ID NOT IN ('OUT', 'TRN') AND AT_CASELOAD_LOCATIONS.CASELOAD_ID NOT IN ('ADMINC', 'CADM_I', 'MULTI') ) AND ( AT_OFFENDER_BOOKING.OFFENDER_BOOK_ID = DT_OFFENDER_CSR_ASSESSMENT.OFFENDER_BOOK_ID(+) ) AND ( (AT_OFFENDER_BOOKING.ACTIVE_FLAG = 'Y') AND ( DT_OFFENDER_CSR_ASSESSMENT.row_seq_filter = 1 or DT_OFFENDER_CSR_ASSESSMENT.row_seq_filter is null ) AND ( AT_OFFENDERS_LOCATIONS.AGY_LOC_ID in ((SELECT establishment_code FROM prompt_)) or 'All' in ((SELECT establishment_code FROM prompt_)) ) AND AT_OFFENDERS_LOCATIONS.AGY_LOC_ID <> 'ZZGHI' AND ( USER_ACCESSIBLE_CASELOADS.USERNAME = (SELECT username FROM context_) ) ) ), dataset_base_ AS( SELECT DISTINCT AT_OFFENDER.OFFENDER_ID_DISPLAY, AT_OFFENDER.LAST_NAME, AT_OFFENDER.FIRST_NAME, AT_OFFENDER.BIRTH_DATE, AT_AGENCY_INTERNAL_LOCATION_L4.DESCRIPTION, AT_OFFENDER_BOOKING.IN_OUT_STATUS, trunc( months_between(sysdate, AT_OFFENDER.BIRTH_DATE) / 12 ) AS AGE, AT_OFFENDERS_LOCATIONS.DESCRIPTION AS ESTABLISHMENT_NAME, AT_OFFENDERS_LOCATIONS.AGY_LOC_ID, sysdate, DP6_.APPROVED_RESULT, DP6_.CALC_SUP_LEVEL_TYPE, DP6_.OVERRIDED_SUP_LEVEL_TYPE, DP7_.FROM_AGY_LOC_ID, DP7_.TO_AGY_LOC_ID FROM DP6_, DP7_, OMS_OWNER.OFFENDERS AT_OFFENDER, OMS_OWNER.AGENCY_INTERNAL_LOCATIONS AT_AGENCY_INTERNAL_LOCATION_L4, OMS_OWNER.OFFENDER_BOOKINGS AT_OFFENDER_BOOKING, OMS_OWNER.AGENCY_LOCATIONS AT_OFFENDERS_LOCATIONS, OMS_OWNER.AGENCY_LOCATIONS AT_WING_ESTABLISHMENT, OMS_OWNER.CASELOAD_AGENCY_LOCATIONS AT_CASELOAD_LOCATIONS, USER_ACCESSIBLE_CASELOADS WING_CASELOAD_SECURITY, USER_ACCESSIBLE_CASELOADS WHERE ( AT_OFFENDER.OFFENDER_ID = AT_OFFENDER_BOOKING.OFFENDER_ID ) AND ( AT_OFFENDER.OFFENDER_ID_DISPLAY = DP6_.OFFENDER_ID_DISPLAY ) AND ( AT_OFFENDER.OFFENDER_ID_DISPLAY = DP7_.OFFENDER_ID_DISPLAY ) AND ( AT_OFFENDER_BOOKING.LIVING_UNIT_ID = AT_AGENCY_INTERNAL_LOCATION_L4.INTERNAL_LOCATION_ID ) AND ( AT_OFFENDERS_LOCATIONS.AGENCY_LOCATION_TYPE = 'INST' ) AND ( USER_ACCESSIBLE_CASELOADS.USERNAME = (SELECT username FROM context_) ) AND ( AT_OFFENDERS_LOCATIONS.AGY_LOC_ID = USER_ACCESSIBLE_CASELOADS.CASELOAD_ID ) AND ( AT_CASELOAD_LOCATIONS.AGY_LOC_ID = AT_OFFENDER_BOOKING.AGY_LOC_ID ) AND ( AT_CASELOAD_LOCATIONS.AGY_LOC_ID = AT_OFFENDERS_LOCATIONS.AGY_LOC_ID(+) ) AND ( AT_CASELOAD_LOCATIONS.AGY_LOC_ID NOT IN ('OUT', 'TRN') AND AT_CASELOAD_LOCATIONS.CASELOAD_ID NOT IN ('ADMINC', 'CADM_I', 'MULTI') ) AND ( AT_AGENCY_INTERNAL_LOCATION_L4.AGY_LOC_ID = AT_WING_ESTABLISHMENT.AGY_LOC_ID ) AND ( AT_WING_ESTABLISHMENT.AGY_LOC_ID = WING_CASELOAD_SECURITY.CASELOAD_ID ) AND ( WING_CASELOAD_SECURITY.USERNAME = (SELECT username FROM context_) ) AND ( USER_ACCESSIBLE_CASELOADS.USERNAME = (SELECT username FROM context_) ) AND ( USER_ACCESSIBLE_CASELOADS.USERNAME = (SELECT username FROM context_) ) AND ( (AT_OFFENDER_BOOKING.ACTIVE_FLAG = 'Y') AND ( AT_OFFENDERS_LOCATIONS.AGY_LOC_ID in ((SELECT establishment_code FROM prompt_)) or 'All' in ((SELECT establishment_code FROM prompt_)) ) AND AT_OFFENDERS_LOCATIONS.AGY_LOC_ID <> 'ZZGHI' AND ( USER_ACCESSIBLE_CASELOADS.USERNAME = (SELECT username FROM context_) ) ) ), dataset_ AS ( select OFFENDER_ID_DISPLAY, LAST_NAME, FIRST_NAME, BIRTH_DATE, DESCRIPTION, IN_OUT_STATUS, AGE, ESTABLISHMENT_NAME, AGY_LOC_ID, APPROVED_RESULT, FROM_AGY_LOC_ID, TO_AGY_LOC_ID, SYSDATE AS TODAY_, CASE WHEN NOT(APPROVED_RESULT IS NULL) THEN CASE WHEN APPROVED_RESULT='HI' THEN 'HIGH' ELSE APPROVED_RESULT END WHEN NOT(OVERRIDED_SUP_LEVEL_TYPE IS NULL) THEN CASE WHEN OVERRIDED_SUP_LEVEL_TYPE='HI' THEN 'HIGH' ELSE OVERRIDED_SUP_LEVEL_TYPE END ELSE CASE WHEN CALC_SUP_LEVEL_TYPE='HI' THEN 'HIGH' ELSE CALC_SUP_LEVEL_TYPE END END AS V_CSRA from dataset_base_)",
+      "parameters": [
+        {
+          "index": 0,
+          "name": "establishment_code",
+          "filterType": "autocomplete",
+          "referenceType": "establishment",
+          "reportFieldType": "string",
+          "display": "Establishment",
+          "description": "@Prompt('Establishment Code','A','Establishment\\Establishment Code',mono,free,,Not_Persistent,,User:3)",
+          "mandatory": "true"
+        }
+      ],
+      "schema": {
+        "field": [
+          {
+            "index": 0,
+            "name": "OFFENDER_ID_DISPLAY",
+            "type": "string",
+            "display": "NOMS Number",
+            "legacyId": "DP0.DO10044",
+            "legacySqlClass": "column"
+          },
+          {
+            "index": 1,
+            "name": "LAST_NAME",
+            "type": "string",
+            "display": "Last Name",
+            "legacyId": "DP0.DO10045",
+            "legacySqlClass": "column"
+          },
+          {
+            "index": 2,
+            "name": "FIRST_NAME",
+            "type": "string",
+            "display": "First Name",
+            "legacyId": "DP0.DO10046",
+            "legacySqlClass": "column"
+          },
+          {
+            "index": 3,
+            "name": "BIRTH_DATE",
+            "type": "date",
+            "display": "Date of Birth",
+            "legacyId": "DP0.DO10075",
+            "legacySqlClass": "column"
+          },
+          {
+            "index": 4,
+            "name": "DESCRIPTION",
+            "type": "string",
+            "display": "Cell Location",
+            "legacyId": "DP0.DO1042a",
+            "legacySqlClass": "column"
+          },
+          {
+            "index": 5,
+            "name": "IN_OUT_STATUS",
+            "type": "string",
+            "display": "In Out Status",
+            "legacyId": "DP0.DO10cde",
+            "legacySqlClass": "column"
+          },
+          {
+            "index": 6,
+            "name": "AGE",
+            "type": "double",
+            "display": "Age",
+            "legacyId": "DP0.DO10072",
+            "legacySqlClass": "column"
+          },
+          {
+            "index": 7,
+            "name": "ESTABLISHMENT_NAME",
+            "type": "string",
+            "display": "Establishment Name",
+            "legacyId": "DP0.DO1033b",
+            "legacySqlClass": "column"
+          },
+          {
+            "index": 8,
+            "name": "AGY_LOC_ID",
+            "type": "string",
+            "display": "Establishment Code",
+            "legacyId": "DP0.DO1043b",
+            "legacySqlClass": "column"
+          },
+          {
+            "index": 9,
+            "name": "APPROVED_RESULT",
+            "type": "date",
+            "display": "Approved Result",
+            "legacyId": "DP0.DO10edf",
+            "legacySqlClass": "column"
+          },
+          {
+            "index": 10,
+            "name": "FROM_AGY_LOC_ID",
+            "type": "string",
+            "display": "V_FROM",
+            "legacyId": "???",
+            "legacySqlClass": "alias"
+          },
+          {
+            "index": 11,
+            "name": "TO_AGY_LOC_ID",
+            "type": "string",
+            "display": "V_TO",
+            "legacyId": "???",
+            "legacySqlClass": "alias"
+          },
+          {
+            "index": 12,
+            "name": "TODAY_",
+            "type": "date",
+            "display": "",
+            "legacyId": "DP0.DO10edf",
+            "legacySqlClass": "column"
+          },
+          {
+            "index": 13,
+            "name": "V_CSRA",
+            "type": "string",
+            "display": "CSRA",
+            "legacyId": "???",
+            "legacySqlClass": "alias"
+          }
+        ]
+      }
+    },
+    {
+      "id": "3376286/DP6",
+      "name": "CRSA",
+      "description": "OR - Sentence",
+      "datasource": "nomis",
+      "query": "dataset_base_ AS (SELECT DISTINCT AT_OFFENDER.OFFENDER_ID_DISPLAY AS OFFENDER_ID_DISPLAY, DT_OFFENDER_CSR_ASSESSMENT.ASSESSMENT_DATE AS ASSESSMENT_DATE, DT_OFFENDER_CSR_ASSESSMENT.APPROVED_RESULT AS APPROVED_RESULT, DT_OFFENDER_CSR_ASSESSMENT.CALC_SUP_LEVEL_TYPE AS CALC_SUP_LEVEL_TYPE, DT_OFFENDER_CSR_ASSESSMENT.NEXT_REVIEW_DATE AS NEXT_REVIEW_DATE, DT_OFFENDER_CSR_ASSESSMENT.OVERRIDED_SUP_LEVEL_TYPE AS OVERRIDED_SUP_LEVEL_TYPE FROM OMS_OWNER.OFFENDERS AT_OFFENDER, OMS_OWNER.OFFENDER_BOOKINGS AT_OFFENDER_BOOKING, OMS_OWNER.AGENCY_LOCATIONS AT_OFFENDERS_LOCATIONS, OMS_OWNER.CASELOAD_AGENCY_LOCATIONS AT_CASELOAD_LOCATIONS, (SELECT offender_book_id, assessment_date, assessment_type, calc_sup_level_type, overrided_sup_level_type, approved_result, authority, next_review_date, assessment_seq, assess_status, score, coalesced_result, coalesced_result_description, row_seq_filter FROM (SELECT v.*, rc.description AS coalesced_result_description FROM (SELECT offender_book_id, assessment_date, assessment_type, calc_sup_level_type, overrided_sup_level_type, approved_result, authority, next_review_date, assessment_seq, assess_status, score, coalesced_result, CASE WHEN row_seq_filter_latest = 1 THEN 1 ELSE row_seq_filter_previous END AS row_seq_filter FROM (SELECT offender_book_id, assessment_date, assessment_type, calc_sup_level_type, overrided_sup_level_type, approved_result, authority, next_review_date, assessment_seq, assess_status, score, coalesced_result, CASE WHEN row_seq_filter_latest = 1 AND assess_status = 'A' THEN 1 ELSE 0 END AS row_seq_filter_latest, COUNT(CASE WHEN row_seq_filter_previous = 1 AND assess_status <> 'A' THEN 1 END) OVER (PARTITION BY offender_book_id) + row_seq_filter_previous AS row_seq_filter_previous FROM (SELECT oa.offender_book_id, oa.assessment_date, a.description AS assessment_type, oa.calc_sup_level_type, oa.overrided_sup_level_type, oa.review_sup_level_type AS approved_result, oa.review_committe_code AS authority, oa.next_review_date, oa.assessment_seq, oa.assess_status, oa.score, COALESCE(oa.review_sup_level_type, oa.overrided_sup_level_type, oa.calc_sup_level_type) AS coalesced_result, ROW_NUMBER() OVER (PARTITION BY oa.offender_book_id ORDER BY oa.assess_status, oa.assessment_date DESC, oa.assessment_seq DESC) AS row_seq_filter_latest, ROW_NUMBER() OVER (PARTITION BY oa.offender_book_id ORDER BY oa.assessment_date DESC, oa.assessment_seq DESC) AS row_seq_filter_previous FROM offender_assessments oa INNER JOIN assessments a ON a.assessment_id = oa.assessment_type_id AND a.assessment_class = 'TYPE' AND a.cell_sharing_alert_flag = 'Y'))) v LEFT OUTER JOIN reference_codes rc ON rc.code = v.coalesced_result AND rc.domain = 'SUP_LVL_TYPE')) DT_OFFENDER_CSR_ASSESSMENT, USER_ACCESSIBLE_CASELOADS WHERE (AT_OFFENDER.OFFENDER_ID = AT_OFFENDER_BOOKING.OFFENDER_ID) AND (AT_OFFENDERS_LOCATIONS.AGENCY_LOCATION_TYPE = 'INST') AND (USER_ACCESSIBLE_CASELOADS.USERNAME = UPPER('WQB43L')) AND (AT_OFFENDERS_LOCATIONS.AGY_LOC_ID = USER_ACCESSIBLE_CASELOADS.CASELOAD_ID) AND (AT_CASELOAD_LOCATIONS.AGY_LOC_ID = AT_OFFENDER_BOOKING.AGY_LOC_ID) AND (AT_CASELOAD_LOCATIONS.AGY_LOC_ID = AT_OFFENDERS_LOCATIONS.AGY_LOC_ID (+)) AND (NOT AT_CASELOAD_LOCATIONS.AGY_LOC_ID IN ('OUT', 'TRN') AND NOT AT_CASELOAD_LOCATIONS.CASELOAD_ID IN ('ADMINC', 'CADM_I', 'MULTI')) AND (AT_OFFENDER_BOOKING.OFFENDER_BOOK_ID = DT_OFFENDER_CSR_ASSESSMENT.OFFENDER_BOOK_ID (+)) AND ((AT_OFFENDER_BOOKING.ACTIVE_FLAG = 'Y') AND (DT_OFFENDER_CSR_ASSESSMENT.row_seq_filter = 1 OR DT_OFFENDER_CSR_ASSESSMENT.row_seq_filter IS NULL) AND (AT_OFFENDERS_LOCATIONS.AGY_LOC_ID IN ('ACI') OR 'All' IN ('ACI')) AND AT_OFFENDERS_LOCATIONS.AGY_LOC_ID <> 'ZZGHI' AND (USER_ACCESSIBLE_CASELOADS.USERNAME = UPPER('WQB43L')))), dataset_ AS (SELECT OFFENDER_ID_DISPLAY, ASSESSMENT_DATE, APPROVED_RESULT, CALC_SUP_LEVEL_TYPE, NEXT_REVIEW_DATE, OVERRIDED_SUP_LEVEL_TYPE FROM dataset_base_)",
+      "parameters": [],
+      "schema": {
+        "field": [
+          {
+            "index": 0,
+            "name": "OFFENDER_ID_DISPLAY",
+            "type": "string",
+            "display": "NOMS Number",
+            "legacyId": "DP6.DO10044",
+            "legacySqlClass": "column"
+          },
+          {
+            "index": 1,
+            "name": "ASSESSMENT_DATE",
+            "type": "date",
+            "display": "CSRA Date",
+            "legacyId": "DP6.DO10c2b",
+            "legacySqlClass": "column"
+          },
+          {
+            "index": 2,
+            "name": "APPROVED_RESULT",
+            "type": "string",
+            "display": "CSRA Approved Result",
+            "legacyId": "DP6.DO10c50",
+            "legacySqlClass": "column"
+          },
+          {
+            "index": 3,
+            "name": "CALC_SUP_LEVEL_TYPE",
+            "type": "string",
+            "display": "CSRA Calculated Result",
+            "legacyId": "DP6.DO10c2f",
+            "legacySqlClass": "column"
+          },
+          {
+            "index": 4,
+            "name": "NEXT_REVIEW_DATE",
+            "type": "date",
+            "display": "CSRA Review Date",
+            "legacyId": "DP6.DO10c30",
+            "legacySqlClass": "column"
+          },
+          {
+            "index": 5,
+            "name": "OVERRIDED_SUP_LEVEL_TYPE",
+            "type": "string",
+            "display": "CSRA Override Result",
+            "legacyId": "DP6.DO10c4e",
+            "legacySqlClass": "column"
+          }
+        ]
+      }
+    },
+    {
+      "id": "3376286/DP7",
+      "name": "Movement",
+      "description": "OR - Sentence",
+      "datasource": "nomis",
+      "query": "dataset_base_ AS (SELECT DISTINCT AT_OFFENDER.OFFENDER_ID_DISPLAY AS OFFENDER_ID_DISPLAY, COALESCE(AT_EXT_MOV_FROM_AGY.DESCRIPTION, AT_FROM_CITY_CODES.DESCRIPTION, AT_FROM_ADDRESS_ATTENDED.STREET || ' ' || AT_FROM_ADDRESS_ATTENDED.LOCALITY || ' ' || AT_FROM_ADDRESS_ATTENDED.POSTAL_CODE) AS FROM_, COALESCE(AT_EXT_MOV_TO_AGY.DESCRIPTION, AT_TO_CITY_CODES.DESCRIPTION, AT_TO_ADDRESS_ATTENDED.STREET || ' ' || AT_TO_ADDRESS_ATTENDED.LOCALITY || ' ' || AT_TO_ADDRESS_ATTENDED.POSTAL_CODE) AS TO_, AT_OFFENDER_EXTERNAL_MOVEMENTS.FROM_AGY_LOC_ID AS FROM_AGY_LOC_ID, AT_OFFENDER_EXTERNAL_MOVEMENTS.TO_AGY_LOC_ID AS TO_AGY_LOC_ID, AT_OFFENDER_EXTERNAL_MOVEMENTS.MOVEMENT_SEQ AS MOVEMENT_SEQ FROM OMS_OWNER.OFFENDERS AT_OFFENDER, OMS_OWNER.REFERENCE_CODES AT_FROM_CITY_CODES, OMS_OWNER.REFERENCE_CODES AT_TO_CITY_CODES, OMS_OWNER.OFFENDER_BOOKINGS AT_OFFENDER_BOOKING, OMS_OWNER.AGENCY_LOCATIONS AT_EXT_MOV_FROM_AGY, OMS_OWNER.AGENCY_LOCATIONS AT_EXT_MOV_TO_AGY, OMS_OWNER.AGENCY_LOCATIONS AT_OFFENDERS_LOCATIONS, OMS_OWNER.OFFENDER_EXTERNAL_MOVEMENTS AT_OFFENDER_EXTERNAL_MOVEMENTS, OMS_OWNER.CASELOAD_AGENCY_LOCATIONS AT_CASELOAD_LOCATIONS, ADDRESSES AT_FROM_ADDRESS_ATTENDED, ADDRESSES AT_TO_ADDRESS_ATTENDED, USER_ACCESSIBLE_CASELOADS, (SELECT OFFENDER_BOOK_ID, MOVEMENT_SEQ, MAX(MOVEMENT_TIME) OVER (PARTITION BY offender_book_id) AS MOVEMENT_TIME FROM OMS_OWNER.OFFENDER_EXTERNAL_MOVEMENTS WHERE ACTIVE_FLAG = 'Y') DT_LATEST_EXTERNAL_MOVEMENT WHERE (DT_LATEST_EXTERNAL_MOVEMENT.OFFENDER_BOOK_ID = AT_OFFENDER_EXTERNAL_MOVEMENTS.OFFENDER_BOOK_ID AND DT_LATEST_EXTERNAL_MOVEMENT.MOVEMENT_SEQ = AT_OFFENDER_EXTERNAL_MOVEMENTS.MOVEMENT_SEQ) AND (AT_OFFENDER.OFFENDER_ID = AT_OFFENDER_BOOKING.OFFENDER_ID) AND (AT_OFFENDER_BOOKING.OFFENDER_BOOK_ID = AT_OFFENDER_EXTERNAL_MOVEMENTS.OFFENDER_BOOK_ID (+)) AND (AT_OFFENDERS_LOCATIONS.AGENCY_LOCATION_TYPE = 'INST') AND (USER_ACCESSIBLE_CASELOADS.USERNAME = UPPER('WQB43L')) AND (AT_OFFENDERS_LOCATIONS.AGY_LOC_ID = USER_ACCESSIBLE_CASELOADS.CASELOAD_ID) AND (AT_CASELOAD_LOCATIONS.AGY_LOC_ID = AT_OFFENDER_BOOKING.AGY_LOC_ID) AND (AT_CASELOAD_LOCATIONS.AGY_LOC_ID = AT_OFFENDERS_LOCATIONS.AGY_LOC_ID (+)) AND (NOT AT_CASELOAD_LOCATIONS.AGY_LOC_ID IN ('OUT', 'TRN') AND NOT AT_CASELOAD_LOCATIONS.CASELOAD_ID IN ('ADMINC', 'CADM_I', 'MULTI')) AND (AT_OFFENDER_EXTERNAL_MOVEMENTS.TO_AGY_LOC_ID = AT_EXT_MOV_TO_AGY.AGY_LOC_ID (+)) AND (AT_OFFENDER_EXTERNAL_MOVEMENTS.FROM_AGY_LOC_ID = AT_EXT_MOV_FROM_AGY.AGY_LOC_ID (+)) AND (AT_OFFENDER_EXTERNAL_MOVEMENTS.TO_CITY = AT_TO_CITY_CODES.CODE (+)) AND (AT_TO_CITY_CODES.DOMAIN = 'CITY' OR AT_TO_CITY_CODES.DOMAIN IS NULL) AND (AT_OFFENDER_EXTERNAL_MOVEMENTS.FROM_CITY = AT_FROM_CITY_CODES.CODE (+)) AND (AT_FROM_CITY_CODES.DOMAIN = 'CITY' OR AT_FROM_CITY_CODES.DOMAIN IS NULL) AND (AT_OFFENDER_EXTERNAL_MOVEMENTS.TO_ADDRESS_ID = AT_TO_ADDRESS_ATTENDED.ADDRESS_ID (+)) AND (AT_OFFENDER_EXTERNAL_MOVEMENTS.FROM_ADDRESS_ID = AT_FROM_ADDRESS_ATTENDED.ADDRESS_ID (+)) AND ((AT_OFFENDER_BOOKING.ACTIVE_FLAG = 'Y') AND (AT_OFFENDERS_LOCATIONS.AGY_LOC_ID IN ('ACI') OR 'All' IN ('ACI')) AND AT_OFFENDERS_LOCATIONS.AGY_LOC_ID <> 'ZZGHI' AND (USER_ACCESSIBLE_CASELOADS.USERNAME = UPPER('WQB43L')) AND (DT_LATEST_EXTERNAL_MOVEMENT.OFFENDER_BOOK_ID = AT_OFFENDER_EXTERNAL_MOVEMENTS.OFFENDER_BOOK_ID AND DT_LATEST_EXTERNAL_MOVEMENT.MOVEMENT_TIME = AT_OFFENDER_EXTERNAL_MOVEMENTS.MOVEMENT_TIME))), dataset_ AS (SELECT OFFENDER_ID_DISPLAY, FROM_, TO_, FROM_AGY_LOC_ID, TO_AGY_LOC_ID, MOVEMENT_SEQ FROM dataset_base_)",
+      "parameters": [],
+      "schema": {
+        "field": [
+          {
+            "index": 0,
+            "name": "OFFENDER_ID_DISPLAY",
+            "type": "string",
+            "display": "NOMS Number",
+            "legacyId": "DP7.DO10044",
+            "legacySqlClass": "column"
+          },
+          {
+            "index": 1,
+            "name": "FROM_",
+            "type": "string",
+            "display": "From",
+            "legacyId": "DP7.DO10d98",
+            "legacySqlClass": "column"
+          },
+          {
+            "index": 2,
+            "name": "TO_",
+            "type": "string",
+            "display": "To",
+            "legacyId": "DP7.DO10d99",
+            "legacySqlClass": "column"
+          },
+          {
+            "index": 3,
+            "name": "FROM_AGY_LOC_ID",
+            "type": "string",
+            "display": "From Agy Loc ID",
+            "legacyId": "DP7.DO10454",
+            "legacySqlClass": "column"
+          },
+          {
+            "index": 4,
+            "name": "TO_AGY_LOC_ID",
+            "type": "string",
+            "display": "To Agy Loc ID",
+            "legacyId": "DP7.DO10455",
+            "legacySqlClass": "column"
+          },
+          {
+            "index": 5,
+            "name": "MOVEMENT_SEQ",
+            "type": "double",
+            "display": "Movement Sequence Number",
+            "legacyId": "DP7.DO1083a",
+            "legacySqlClass": "column"
+          }
+        ]
+      }
+    }
+  ],
+  "policy": [
+    {
+      "id": "access",
+      "type": "access",
+      "rule": [
+        {
+          "effect": "permit",
+          "condition": [
+            {
+              "match": ["${role}", "ROLE_PRISONS_REPORTING_USER"]
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "report": [
+    {
+      "id": "178264.RS",
+      "name": "Test Report To Test The DPD Publication Pipeline",
+      "classification": "OFFICIAL",
+      "version": "1.0.0",
+      "render": "HTML",
+      "dataset": "3376286/DP0",
+      "filter": {
+        "name": "prefilter_",
+        "query": "prefilter_ AS (SELECT * FROM dataset_)"
+      },
+      "feature": [
+        {
+          "type": "print"
+        }
+      ],
+      "specification": {
+        "template": "list",
+        "field": [
+          {
+            "name": "$ref:OFFENDER_ID_DISPLAY",
+            "display": "NOMS Number",
+            "formula": "",
+            "visible": "true",
+            "sortable": true,
+            "defaultsort": true,
+            "legacyId": "DP0.DO10045"
+          },
+          {
+            "name": "$ref:LAST_NAME",
+            "display": "Last Name",
+            "formula": "",
+            "visible": "true",
+            "sortable": true,
+            "defaultsort": false,
+            "legacyId": "DP0.DO10045"
+          },
+          {
+            "name": "$ref:FIRST_NAME",
+            "display": "First Name",
+            "formula": "",
+            "visible": "true",
+            "sortable": true,
+            "defaultsort": false,
+            "legacyId": "DP0.DO10046"
+          },
+          {
+            "name": "$ref:BIRTH_DATE",
+            "display": "Date of Birth",
+            "formula": "format_date(${BIRTH_DATE}, 'dd/MM/yyyy')",
+            "visible": "true",
+            "sortable": true,
+            "defaultsort": false,
+            "legacyId": "DP0.DO10075"
+          },
+          {
+            "name": "$ref:IN_OUT_STATUS",
+            "display": "In Out Status",
+            "formula": "",
+            "visible": "true",
+            "sortable": true,
+            "defaultsort": false,
+            "legacyId": "DP0.DO10cde"
+          },
+          {
+            "name": "$ref:AGY_LOC_ID",
+            "display": "Establishment Code",
+            "formula": "",
+            "visible": "true",
+            "sortable": true,
+            "defaultsort": false,
+            "legacyId": "DP0.DO1043b"
+          },
+          {
+            "name": "$ref:ESTABLISHMENT_NAME",
+            "display": "Establishment Name",
+            "formula": "",
+            "visible": "true",
+            "sortable": true,
+            "defaultsort": false,
+            "legacyId": "DP0.DO1033b"
+          },
+          {
+            "name": "$ref:DESCRIPTION",
+            "display": "Cell Location",
+            "formula": "",
+            "visible": "true",
+            "sortable": true,
+            "defaultsort": false,
+            "legacyId": "DP0.DO1042a"
+          },
+          {
+            "name": "$ref:V_CSRA",
+            "display": "CSRA",
+            "formula": "",
+            "visible": "true",
+            "sortable": false,
+            "defaultsort": false,
+            "legacySql": "=If ([v_CSRA_If]=\"HI\") Then \"HIGH\" Else Upper( [v_CSRA_If])"
+          },
+          {
+            "name": "$ref:FROM_AGY_LOC_ID",
+            "display": "From",
+            "formula": "",
+            "visible": "true",
+            "sortable": false,
+            "defaultsort": false,
+            "legacySql": "=[From Agy Loc ID]"
+          },
+          {
+            "name": "$ref:TO_AGY_LOC_ID",
+            "display": "To",
+            "formula": "",
+            "visible": "true",
+            "sortable": false,
+            "defaultsort": false,
+            "legacySql": "=[To Agy Loc ID]"
+          },
+          {
+            "name": "$ref:TODAY_",
+            "display": "Extract Date",
+            "formula": "",
+            "visible": "true",
+            "sortable": false,
+            "defaultsort": false,
+            "legacyId": "DP0.DO10edf"
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -92,15 +92,6 @@
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
       "license": "MIT"
     },
-    "node_modules/lru-cache": {
-      "version": "11.3.2",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.2.tgz",
-      "integrity": "sha512-wgWa6FWQ3QRRJbIjbsldRJZxdxYngT/dO0I5Ynmlnin8qy7tC6xYzbcJjtN4wHLXtkbVwHzk0C+OejVw1XM+DQ==",
-      "license": "BlueOak-1.0.0",
-      "engines": {
-        "node": "20 || >=22"
-      }
-    },
     "node_modules/minimatch": {
       "version": "10.2.5",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
@@ -139,6 +130,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/path-scurry/node_modules/lru-cache": {
+      "version": "11.2.7",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.7.tgz",
+      "integrity": "sha512-aY/R+aEsRelme17KGQa/1ZSIpLpNYYrhcrepKTZgE+W3WM16YMCaPwOHLHsmopZHELU0Ojin1lPVxKR0MihncA==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
       }
     },
     "node_modules/require-from-string": {

--- a/package.json
+++ b/package.json
@@ -5,6 +5,9 @@
     "ajv": "8.18.0",
     "glob": "13.0.6"
   },
+  "overrides": {
+    "lru-cache": "11.2.7"
+  },
   "scripts": {
     "validate": "node scripts/validateDpdsSchemaCompliance.js",
     "uniqueness": "node scripts/ensureUniqueness.js"

--- a/scripts/validateDpdsSchemaCompliance.js
+++ b/scripts/validateDpdsSchemaCompliance.js
@@ -21,6 +21,8 @@ for (const file of files) {
     const data = JSON.parse(fs.readFileSync(file));
     if (!validate(data)) {
         const filteredErrors = validate.errors.filter(
+            //The below exclusion is temporary to match previous validation behaviour.
+            //Long term the DPDs will have to be brought in line with the schema.
             err => err.keyword !== "additionalProperties"
         );
 

--- a/scripts/validateDpdsSchemaCompliance.js
+++ b/scripts/validateDpdsSchemaCompliance.js
@@ -20,9 +20,15 @@ let valid = true;
 for (const file of files) {
     const data = JSON.parse(fs.readFileSync(file));
     if (!validate(data)) {
-        console.error(`Errors in ${file}:`);
-        console.error(JSON.stringify(validate.errors, null, 2));
-        valid = false;
+        const filteredErrors = validate.errors.filter(
+            err => err.keyword !== "additionalProperties"
+        );
+
+        if (filteredErrors.length > 0) {
+            console.error(`Errors in ${file}:`);
+            console.error(JSON.stringify(filteredErrors, null, 2));
+            valid = false;
+        }
     }
 }
 

--- a/scripts/validateDpdsSchemaCompliance.js
+++ b/scripts/validateDpdsSchemaCompliance.js
@@ -10,7 +10,7 @@ const glob = require("glob");
 
 const schema = JSON.parse(fs.readFileSync(process.env.SCHEMA_LOCATION));
 
-const ajv = new Ajv({ allErrors: true });
+const ajv = new Ajv({ allErrors: true, strict: false, coerceTypes: true });
 const validate = ajv.compile(schema);
 
 const files = glob.sync("dpd/**/*.json");


### PR DESCRIPTION
Added a test report to confirm the DPD publication pipeline works after the changes to remove the flagged Github Actions.
Temporarily ignore additionalProperties check to match behaviour of the previous 3rd party Github Actions validation.
The proper long term fix will be to bring the DPDs in line with the schema. 
For example when additionalProperties is false in the schema, then the extra properties will need to be deleted from the DPD.