### PR TITLE
IR-1598 DARU Incident Tracker date range filtering and PECS caseload policy 

### DIFF
--- a/dpd/dev/definitions/prisons/orphanage/incident-report-pecs.json
+++ b/dpd/dev/definitions/prisons/orphanage/incident-report-pecs.json
@@ -33,6 +33,25 @@
           ]
         }
       ]
+    },
+    {
+      "id": "caseloads",
+      "type": "row-level",
+      "action": [
+        "location IN (${caseloads}) OR location IN (SELECT agy_loc_id FROM prisons.nomis_agency_locations WHERE agency_location_type = 'PECS')"
+      ],
+      "rule": [
+        {
+          "effect": "permit",
+          "condition": [
+            {
+              "exists": [
+                "${caseloads}"
+              ]
+            }
+          ]
+        }
+      ]
     }
   ],
   "dataset": [
@@ -190,7 +209,7 @@
       "id": "prisons",
       "name": "Prisons",
       "datasource": "datamart",
-      "query": "select prison_id, name prison_name FROM prisons.prisonregister_prison p where p.active = true order by name",
+      "query": "select prison_id, name prison_name FROM prisons.prisonregister_prison p where p.active = true union SELECT agy_loc_id prison_id, initcap(description) prison_name FROM prisons.nomis_agency_locations WHERE agency_location_type = 'PECS' and active_flag = 'Y' and agy_loc_id != 'NOU' order by prison_name",
       "schema": {
         "field": [
           {

--- a/dpd/dev/definitions/prisons/orphanage/incident-status-tracker.json
+++ b/dpd/dev/definitions/prisons/orphanage/incident-status-tracker.json
@@ -113,7 +113,25 @@
       "name": "Incident counts by status and type",
       "description": "Incident counts by location, type and status",
       "datasource": "athena",
-      "query": "SELECT \n    format_datetime(min(r.incident_date_and_time), 'dd/MM/yyyy') start_date,\n    format_datetime(max(r.incident_date_and_time), 'dd/MM/yyyy') end_date,\n    r.location as location,\n    p.name AS location_name, \n    ctf.code as raw_code,\n    COALESCE( ctf.code, '1-ALL') AS incident_code, \n    COALESCE(ctf.description, 'All incident types') AS incident_type, \n    cs.code AS status_code, \n    cs.description  AS status, \n    COUNT(r.id) AS TOTAL \nFROM prisons.incidentreporting_report r \nJOIN prisons.incidentreporting_constant_type ct \n    ON r.type = ct.code \nJOIN prisons.incidentreporting_constant_type_family ctf \n    ON ctf.code = ct.family_code \nJOIN prisons.incidentreporting_constant_status cs \n    ON cs.code = r.status \nJOIN prisons.prisonregister_prison p \n    ON p.prison_id = r.location and p.active = true\nWHERE cs.code NOT IN ('DUPLICATE', 'NOT_REPORTABLE')\nGROUP BY GROUPING SETS (\n    (r.location, p.name, ctf.code, ctf.description, cs.code, cs.description), \n    (r.location, p.name, cs.code, cs.description)\n)\nORDER BY p.name, ctf.description, cs.description",
+      "query": "SELECT \n    format_datetime(min(r.incident_date_and_time), 'dd/MM/yyyy') start_date,\n    format_datetime(max(r.incident_date_and_time), 'dd/MM/yyyy') end_date,\n    r.location as location,\n    p.name AS location_name, \n    ctf.code as raw_code,\n    COALESCE( ctf.code, '1-ALL') AS incident_code, \n    COALESCE(ctf.description, 'All incident types') AS incident_type, \n    cs.code AS status_code, \n    cs.description  AS status, \n    COUNT(r.id) AS TOTAL \nFROM prisons.incidentreporting_report r \nJOIN prisons.incidentreporting_constant_type ct \n    ON r.type = ct.code \nJOIN prisons.incidentreporting_constant_type_family ctf \n    ON ctf.code = ct.family_code \nJOIN prisons.incidentreporting_constant_status cs \n    ON cs.code = r.status \nJOIN prisons.prisonregister_prison p \n    ON p.prison_id = r.location and p.active = true\nWHERE cs.code NOT IN ('DUPLICATE', 'NOT_REPORTABLE')\n and date(r.incident_date_and_time) >= (SELECT START_DATE from prompt_) and date(r.incident_date_and_time) <= (SELECT END_DATE from prompt_) \nGROUP BY GROUPING SETS (\n    (r.location, p.name, ctf.code, ctf.description, cs.code, cs.description), \n    (r.location, p.name, cs.code, cs.description)\n)\nORDER BY p.name, ctf.description, cs.description",
+      "parameters": [
+        {
+          "index": 0,
+          "name": "start_date",
+          "filterType": "date",
+          "reportFieldType": "date",
+          "display": "Start incident date",
+          "mandatory": "true"
+        },
+        {
+          "index": 1,
+          "name": "end_date",
+          "filterType": "date",
+          "reportFieldType": "date",
+          "display": "End incident date",
+          "mandatory": "true"
+        }
+      ],
       "schema": {
         "field": [
           {

--- a/dpd/preprod/definitions/prisons/orphanage/incident-report-pecs.json
+++ b/dpd/preprod/definitions/prisons/orphanage/incident-report-pecs.json
@@ -33,6 +33,25 @@
           ]
         }
       ]
+    },
+    {
+      "id": "caseloads",
+      "type": "row-level",
+      "action": [
+        "location IN (${caseloads}) OR location IN (SELECT agy_loc_id FROM prisons.nomis_agency_locations WHERE agency_location_type = 'PECS')"
+      ],
+      "rule": [
+        {
+          "effect": "permit",
+          "condition": [
+            {
+              "exists": [
+                "${caseloads}"
+              ]
+            }
+          ]
+        }
+      ]
     }
   ],
   "dataset": [
@@ -190,7 +209,7 @@
       "id": "prisons",
       "name": "Prisons",
       "datasource": "datamart",
-      "query": "select prison_id, name prison_name FROM prisons.prisonregister_prison p where p.active = true order by name",
+      "query": "select prison_id, name prison_name FROM prisons.prisonregister_prison p where p.active = true union SELECT agy_loc_id prison_id, initcap(description) prison_name FROM prisons.nomis_agency_locations WHERE agency_location_type = 'PECS' and active_flag = 'Y' and agy_loc_id != 'NOU' order by prison_name",
       "schema": {
         "field": [
           {

--- a/dpd/preprod/definitions/prisons/orphanage/incident-status-tracker.json
+++ b/dpd/preprod/definitions/prisons/orphanage/incident-status-tracker.json
@@ -113,7 +113,25 @@
       "name": "Incident counts by status and type",
       "description": "Incident counts by location, type and status",
       "datasource": "athena",
-      "query": "SELECT \n    format_datetime(min(r.incident_date_and_time), 'dd/MM/yyyy') start_date,\n    format_datetime(max(r.incident_date_and_time), 'dd/MM/yyyy') end_date,\n    r.location as location,\n    p.name AS location_name, \n    ctf.code as raw_code,\n    COALESCE( ctf.code, '1-ALL') AS incident_code, \n    COALESCE(ctf.description, 'All incident types') AS incident_type, \n    cs.code AS status_code, \n    cs.description  AS status, \n    COUNT(r.id) AS TOTAL \nFROM prisons.incidentreporting_report r \nJOIN prisons.incidentreporting_constant_type ct \n    ON r.type = ct.code \nJOIN prisons.incidentreporting_constant_type_family ctf \n    ON ctf.code = ct.family_code \nJOIN prisons.incidentreporting_constant_status cs \n    ON cs.code = r.status \nJOIN prisons.prisonregister_prison p \n    ON p.prison_id = r.location and p.active = true\nWHERE cs.code NOT IN ('DUPLICATE', 'NOT_REPORTABLE')\nGROUP BY GROUPING SETS (\n    (r.location, p.name, ctf.code, ctf.description, cs.code, cs.description), \n    (r.location, p.name, cs.code, cs.description)\n)\nORDER BY p.name, ctf.description, cs.description",
+      "query": "SELECT \n    format_datetime(min(r.incident_date_and_time), 'dd/MM/yyyy') start_date,\n    format_datetime(max(r.incident_date_and_time), 'dd/MM/yyyy') end_date,\n    r.location as location,\n    p.name AS location_name, \n    ctf.code as raw_code,\n    COALESCE( ctf.code, '1-ALL') AS incident_code, \n    COALESCE(ctf.description, 'All incident types') AS incident_type, \n    cs.code AS status_code, \n    cs.description  AS status, \n    COUNT(r.id) AS TOTAL \nFROM prisons.incidentreporting_report r \nJOIN prisons.incidentreporting_constant_type ct \n    ON r.type = ct.code \nJOIN prisons.incidentreporting_constant_type_family ctf \n    ON ctf.code = ct.family_code \nJOIN prisons.incidentreporting_constant_status cs \n    ON cs.code = r.status \nJOIN prisons.prisonregister_prison p \n    ON p.prison_id = r.location and p.active = true\nWHERE cs.code NOT IN ('DUPLICATE', 'NOT_REPORTABLE')\n and date(r.incident_date_and_time) >= (SELECT START_DATE from prompt_) and date(r.incident_date_and_time) <= (SELECT END_DATE from prompt_) \nGROUP BY GROUPING SETS (\n    (r.location, p.name, ctf.code, ctf.description, cs.code, cs.description), \n    (r.location, p.name, cs.code, cs.description)\n)\nORDER BY p.name, ctf.description, cs.description",
+      "parameters": [
+        {
+          "index": 0,
+          "name": "start_date",
+          "filterType": "date",
+          "reportFieldType": "date",
+          "display": "Start incident date",
+          "mandatory": "true"
+        },
+        {
+          "index": 1,
+          "name": "end_date",
+          "filterType": "date",
+          "reportFieldType": "date",
+          "display": "End incident date",
+          "mandatory": "true"
+        }
+      ],
       "schema": {
         "field": [
           {

--- a/dpd/prod/definitions/prisons/orphanage/incident-report-pecs.json
+++ b/dpd/prod/definitions/prisons/orphanage/incident-report-pecs.json
@@ -33,6 +33,25 @@
           ]
         }
       ]
+    },
+    {
+      "id": "caseloads",
+      "type": "row-level",
+      "action": [
+        "location IN (${caseloads}) OR location IN (SELECT agy_loc_id FROM prisons.nomis_agency_locations WHERE agency_location_type = 'PECS')"
+      ],
+      "rule": [
+        {
+          "effect": "permit",
+          "condition": [
+            {
+              "exists": [
+                "${caseloads}"
+              ]
+            }
+          ]
+        }
+      ]
     }
   ],
   "dataset": [
@@ -190,7 +209,7 @@
       "id": "prisons",
       "name": "Prisons",
       "datasource": "datamart",
-      "query": "select prison_id, name prison_name FROM prisons.prisonregister_prison p where p.active = true order by name",
+      "query": "select prison_id, name prison_name FROM prisons.prisonregister_prison p where p.active = true union SELECT agy_loc_id prison_id, initcap(description) prison_name FROM prisons.nomis_agency_locations WHERE agency_location_type = 'PECS' and active_flag = 'Y' and agy_loc_id != 'NOU' order by prison_name",
       "schema": {
         "field": [
           {

--- a/dpd/prod/definitions/prisons/orphanage/incident-status-tracker.json
+++ b/dpd/prod/definitions/prisons/orphanage/incident-status-tracker.json
@@ -113,7 +113,25 @@
       "name": "Incident counts by status and type",
       "description": "Incident counts by location, type and status",
       "datasource": "athena",
-      "query": "SELECT \n    format_datetime(min(r.incident_date_and_time), 'dd/MM/yyyy') start_date,\n    format_datetime(max(r.incident_date_and_time), 'dd/MM/yyyy') end_date,\n    r.location as location,\n    p.name AS location_name, \n    ctf.code as raw_code,\n    COALESCE( ctf.code, '1-ALL') AS incident_code, \n    COALESCE(ctf.description, 'All incident types') AS incident_type, \n    cs.code AS status_code, \n    cs.description  AS status, \n    COUNT(r.id) AS TOTAL \nFROM prisons.incidentreporting_report r \nJOIN prisons.incidentreporting_constant_type ct \n    ON r.type = ct.code \nJOIN prisons.incidentreporting_constant_type_family ctf \n    ON ctf.code = ct.family_code \nJOIN prisons.incidentreporting_constant_status cs \n    ON cs.code = r.status \nJOIN prisons.prisonregister_prison p \n    ON p.prison_id = r.location and p.active = true\nWHERE cs.code NOT IN ('DUPLICATE', 'NOT_REPORTABLE')\nGROUP BY GROUPING SETS (\n    (r.location, p.name, ctf.code, ctf.description, cs.code, cs.description), \n    (r.location, p.name, cs.code, cs.description)\n)\nORDER BY p.name, ctf.description, cs.description",
+      "query": "SELECT \n    format_datetime(min(r.incident_date_and_time), 'dd/MM/yyyy') start_date,\n    format_datetime(max(r.incident_date_and_time), 'dd/MM/yyyy') end_date,\n    r.location as location,\n    p.name AS location_name, \n    ctf.code as raw_code,\n    COALESCE( ctf.code, '1-ALL') AS incident_code, \n    COALESCE(ctf.description, 'All incident types') AS incident_type, \n    cs.code AS status_code, \n    cs.description  AS status, \n    COUNT(r.id) AS TOTAL \nFROM prisons.incidentreporting_report r \nJOIN prisons.incidentreporting_constant_type ct \n    ON r.type = ct.code \nJOIN prisons.incidentreporting_constant_type_family ctf \n    ON ctf.code = ct.family_code \nJOIN prisons.incidentreporting_constant_status cs \n    ON cs.code = r.status \nJOIN prisons.prisonregister_prison p \n    ON p.prison_id = r.location and p.active = true\nWHERE cs.code NOT IN ('DUPLICATE', 'NOT_REPORTABLE')\n and date(r.incident_date_and_time) >= (SELECT START_DATE from prompt_) and date(r.incident_date_and_time) <= (SELECT END_DATE from prompt_) \nGROUP BY GROUPING SETS (\n    (r.location, p.name, ctf.code, ctf.description, cs.code, cs.description), \n    (r.location, p.name, cs.code, cs.description)\n)\nORDER BY p.name, ctf.description, cs.description",
+      "parameters": [
+        {
+          "index": 0,
+          "name": "start_date",
+          "filterType": "date",
+          "reportFieldType": "date",
+          "display": "Start incident date",
+          "mandatory": "true"
+        },
+        {
+          "index": 1,
+          "name": "end_date",
+          "filterType": "date",
+          "reportFieldType": "date",
+          "display": "End incident date",
+          "mandatory": "true"
+        }
+      ],
       "schema": {
         "field": [
           {

--- a/dpd/test/definitions/prisons/orphanage/incident-report-pecs.json
+++ b/dpd/test/definitions/prisons/orphanage/incident-report-pecs.json
@@ -33,6 +33,25 @@
           ]
         }
       ]
+    },
+    {
+      "id": "caseloads",
+      "type": "row-level",
+      "action": [
+        "location IN (${caseloads}) OR location IN (SELECT agy_loc_id FROM prisons.nomis_agency_locations WHERE agency_location_type = 'PECS')"
+      ],
+      "rule": [
+        {
+          "effect": "permit",
+          "condition": [
+            {
+              "exists": [
+                "${caseloads}"
+              ]
+            }
+          ]
+        }
+      ]
     }
   ],
   "dataset": [
@@ -190,7 +209,7 @@
       "id": "prisons",
       "name": "Prisons",
       "datasource": "datamart",
-      "query": "select prison_id, name prison_name FROM prisons.prisonregister_prison p where p.active = true order by name",
+      "query": "select prison_id, name prison_name FROM prisons.prisonregister_prison p where p.active = true union SELECT agy_loc_id prison_id, initcap(description) prison_name FROM prisons.nomis_agency_locations WHERE agency_location_type = 'PECS' and active_flag = 'Y' and agy_loc_id != 'NOU' order by prison_name",
       "schema": {
         "field": [
           {

--- a/dpd/test/definitions/prisons/orphanage/incident-status-tracker.json
+++ b/dpd/test/definitions/prisons/orphanage/incident-status-tracker.json
@@ -113,7 +113,25 @@
       "name": "Incident counts by status and type",
       "description": "Incident counts by location, type and status",
       "datasource": "athena",
-      "query": "SELECT \n    format_datetime(min(r.incident_date_and_time), 'dd/MM/yyyy') start_date,\n    format_datetime(max(r.incident_date_and_time), 'dd/MM/yyyy') end_date,\n    r.location as location,\n    p.name AS location_name, \n    ctf.code as raw_code,\n    COALESCE( ctf.code, '1-ALL') AS incident_code, \n    COALESCE(ctf.description, 'All incident types') AS incident_type, \n    cs.code AS status_code, \n    cs.description  AS status, \n    COUNT(r.id) AS TOTAL \nFROM prisons.incidentreporting_report r \nJOIN prisons.incidentreporting_constant_type ct \n    ON r.type = ct.code \nJOIN prisons.incidentreporting_constant_type_family ctf \n    ON ctf.code = ct.family_code \nJOIN prisons.incidentreporting_constant_status cs \n    ON cs.code = r.status \nJOIN prisons.prisonregister_prison p \n    ON p.prison_id = r.location and p.active = true\nWHERE cs.code NOT IN ('DUPLICATE', 'NOT_REPORTABLE')\nGROUP BY GROUPING SETS (\n    (r.location, p.name, ctf.code, ctf.description, cs.code, cs.description), \n    (r.location, p.name, cs.code, cs.description)\n)\nORDER BY p.name, ctf.description, cs.description",
+      "query": "SELECT \n    format_datetime(min(r.incident_date_and_time), 'dd/MM/yyyy') start_date,\n    format_datetime(max(r.incident_date_and_time), 'dd/MM/yyyy') end_date,\n    r.location as location,\n    p.name AS location_name, \n    ctf.code as raw_code,\n    COALESCE( ctf.code, '1-ALL') AS incident_code, \n    COALESCE(ctf.description, 'All incident types') AS incident_type, \n    cs.code AS status_code, \n    cs.description  AS status, \n    COUNT(r.id) AS TOTAL \nFROM prisons.incidentreporting_report r \nJOIN prisons.incidentreporting_constant_type ct \n    ON r.type = ct.code \nJOIN prisons.incidentreporting_constant_type_family ctf \n    ON ctf.code = ct.family_code \nJOIN prisons.incidentreporting_constant_status cs \n    ON cs.code = r.status \nJOIN prisons.prisonregister_prison p \n    ON p.prison_id = r.location and p.active = true\nWHERE cs.code NOT IN ('DUPLICATE', 'NOT_REPORTABLE')\n and date(r.incident_date_and_time) >= (SELECT START_DATE from prompt_) and date(r.incident_date_and_time) <= (SELECT END_DATE from prompt_) \nGROUP BY GROUPING SETS (\n    (r.location, p.name, ctf.code, ctf.description, cs.code, cs.description), \n    (r.location, p.name, cs.code, cs.description)\n)\nORDER BY p.name, ctf.description, cs.description",
+      "parameters": [
+        {
+          "index": 0,
+          "name": "start_date",
+          "filterType": "date",
+          "reportFieldType": "date",
+          "display": "Start incident date",
+          "mandatory": "true"
+        },
+        {
+          "index": 1,
+          "name": "end_date",
+          "filterType": "date",
+          "reportFieldType": "date",
+          "display": "End incident date",
+          "mandatory": "true"
+        }
+      ],
       "schema": {
         "field": [
           {


### PR DESCRIPTION

### Changes

**1. DARU Incident Status Tracker — date range filtering**

Added mandatory start and end date parameters to the Incident Tracker dataset query, allowing users to filter incidents by date range. The query now includes:
- Two mandatory `date` filter parameters: `Start incident date` and `End incident date`
- A `WHERE` clause condition filtering `incident_date_and_time` against the provided date range using `prompt_` substitution

**2. PECS Incident Report — caseload-based row-level policy**

Added a row-level security policy to the PECS incident report to prevent users without caseload access to a specific prison from viewing its incidents. The policy:
- Permits rows where `location` matches the user's caseloads (`${caseloads}`)
- Always includes PECS locations (agency type `PECS`) regardless of caseload, as these are not prison-specific
- Updated the prisons filter dataset to also include active PECS locations alongside prison register entries, so PECS locations appear in the location filter dropdown

Both changes are applied across dev, test, preprod, and prod environments.