### PR TITLE
IR-1537 — Prisoner Incident Detail report variant

### DIFF
--- a/dpd/dev/definitions/prisons/orphanage/incident-report.json
+++ b/dpd/dev/definitions/prisons/orphanage/incident-report.json
@@ -8,13 +8,14 @@
     "version": "1.0.0",
     "owner": "Managing Safety",
     "tags": [
-      "DPS", "Incident Reporting"
+      "DPS",
+      "Incident Reporting"
     ]
   },
   "datasource": [
     {
-      "id" : "datamart",
-      "name" : "datamart"
+      "id": "datamart",
+      "name": "datamart"
     }
   ],
   "policy": [
@@ -802,6 +803,161 @@
           },
           {
             "name": "other_method",
+            "type": "string"
+          }
+        ]
+      }
+    },
+    {
+      "id": "prisoner-incident-detail",
+      "name": "Prisoner Involvement in Incidents: Establishment Level",
+      "datasource": "datamart",
+      "query": "WITH qa_pivoted AS (\n    -- We scan the Q&A tables once and pivot all required answers into a single row per report\n    SELECT\n        q.report_id,\n\n        -- Assault Subtypes\n        MAX(CASE WHEN q.code IN ('61287', '44367') THEN\n                     CASE res.code\n                         WHEN '213115' THEN 'Prisoner on prisoner (PoP)'\n                         WHEN '213116' THEN 'Prisoner on staff (PoS)'\n                         WHEN '213117' THEN 'Prisoner on other'\n                         WHEN '213118' THEN 'Other'\n                         WHEN '179730' THEN 'Prisoner on prisoner (PoP)'\n                         WHEN '179732' THEN 'Prisoner on officer (PoS)'\n                         WHEN '179733' THEN 'Prisoner on other'\n                         WHEN '179731' THEN 'Other'\n                         END\n            END) AS assault_subtype,\n\n        -- Find Categories (Newer Versions)\n        MAX(CASE WHEN q.code IN ('67187', '65187') THEN\n                     CASE res.code\n                         WHEN '218783' THEN 'Multiple types'\n                         WHEN '218784' THEN 'Alcohol / hooch / distilling equipment'\n                         WHEN '218785' THEN 'Drug / drug equipment'\n                         WHEN '218786' THEN 'Mobile phone / mobile related item'\n                         WHEN '218787' THEN 'Digital find (excluding mobile phones)'\n                         WHEN '218788' THEN 'Tobacco / tobacco related items'\n                         WHEN '218789' THEN 'Weapon'\n                         WHEN '218790' THEN 'Other reportable items'\n                         WHEN '216784' THEN 'Multiple types'\n                         WHEN '216785' THEN 'Alcohol / hooch / distilling equipment'\n                         WHEN '216786' THEN 'Drug / drug equipment'\n                         WHEN '216787' THEN 'Mobile phone / mobile related item'\n                         WHEN '216788' THEN 'Digital find (excluding mobile phones)'\n                         WHEN '216789' THEN 'Tobacco / tobacco related items'\n                         WHEN '216790' THEN 'Weapon'\n                         WHEN '216791' THEN 'Other reportable items'\n                         END\n            END) AS find_category_new,\n\n        -- Legacy Find Logic Flags\n        MAX(CASE WHEN q.code IN ('49265','51234','51188','57288') AND res.code IN ('195011','198731','196731','209156') THEN 1 ELSE 0 END) AS found_drug,\n        MAX(CASE WHEN q.code IN ('49274','51242','51196','57296') AND res.code IN ('195045','198783','196783','209208') THEN 1 ELSE 0 END) AS found_mobile,\n        MAX(CASE WHEN q.code IN ('49289','51255','51209','57309') AND res.code IN ('195084','198874','196875','209297') THEN 1 ELSE 0 END) AS found_alcohol,\n\n        -- Flags for Assault Details\n        MAX(CASE WHEN (q.code = '61298' AND res.code = '213159') OR (q.code = '44773' AND res.code = '181164') THEN 'Y' END) AS is_serious,\n        MAX(CASE WHEN (q.code = '61305' AND res.code = '213197') OR (q.code = '44522' AND res.code = '180283') THEN 'Y' END) AS is_concussion,\n        MAX(CASE WHEN (q.code = '61285' AND res.code = '213111') OR (q.code = '44586' AND res.code = '180540') THEN 'Y' END) AS is_sexual,\n        MAX(CASE WHEN (q.code = '61300' AND res.code = '213173') OR (q.code = '44141' AND res.code = '178968') THEN 'Y' END) AS is_minor,\n        MAX(CASE WHEN (q.code = '61290' AND res.code = '213126') OR (q.code = '44464' AND res.code = '180077') THEN 'Y' END) AS is_spitting,\n\n        -- Flags for Self-Harm Details\n        MAX(CASE WHEN q.code = '44753' AND res.code = '181110' THEN 'Y' END) AS is_cutting,\n        MAX(CASE WHEN (q.code = '44244' AND res.code = '179302') OR (q.code = '44207' AND res.code = '179187') THEN 'Y' END) AS is_ligature,\n        MAX(CASE WHEN q.code = '45167' AND res.code = '182616' THEN 'Y' END) AS is_burning,\n\n        -- Text fields\n        MAX(CASE WHEN q.code = '61303' THEN\n                     CASE res.code\n                         WHEN '213182' THEN 'Accident and Emergency (A&E)'\n                         WHEN '213183' THEN 'Inpatient (overnight)'\n                         WHEN '213184' THEN 'Inpatient (over 24 hours)'\n                         WHEN '213185' THEN 'Life support'\n                         END\n            END) AS hospital_admission_type,\n        MAX(CASE WHEN (q.code = '61311' AND res.code = '213212') OR (q.code = '45074' AND res.code = '182269') THEN res.additional_information END) AS assault_reason,\n\n        -- FIND_6 Multiple types item detection (Q67205-67225 are exclusive to the Multiple flow)\n        MAX(CASE WHEN q.code = '67205' AND res.code != '218953' THEN 1 ELSE 0 END) AS f6m_alcohol,\n        MAX(CASE WHEN q.code = '67207' AND res.code = '218965' THEN 1 ELSE 0 END) AS f6m_drugs,\n        MAX(CASE WHEN q.code = '67213' AND res.code = '219014' THEN 1 ELSE 0 END) AS f6m_mobile,\n        MAX(CASE WHEN q.code = '67215' AND res.code != '219038' THEN 1 ELSE 0 END) AS f6m_sim,\n        MAX(CASE WHEN q.code = '67216' AND res.code != '219061' THEN 1 ELSE 0 END) AS f6m_memory,\n        MAX(CASE WHEN q.code = '67220' AND res.code != '219091' THEN 1 ELSE 0 END) AS f6m_digital,\n        MAX(CASE WHEN q.code = '67221' AND res.code = '219106' THEN 1 ELSE 0 END) AS f6m_tobacco,\n        MAX(CASE WHEN q.code = '67224' AND res.code != '219115' THEN 1 ELSE 0 END) AS f6m_weapon,\n        -- Incident location (where it took place) \u2014 covers active types + ASSAULT_1 legacy\n        MAX(CASE WHEN q.code IN ('61284', '45134', '45051', '67181', '63182', '49182', '44194', '100000', '44366', '44751', '44717', '45112', '45032', '44496', '44594', '44946', '45178', '45180', '44532', '44463', '44304', '44927') THEN\n            CASE res.code\n                -- ASSAULT_5 Q61284\n                WHEN '213074' THEN 'Administration'\n                WHEN '213075' THEN 'Association area' || COALESCE(' (' || NULLIF(res.additional_information, '') || ')', '')\n                WHEN '213076' THEN 'Cell' || COALESCE(' (' || NULLIF(res.additional_information, '') || ')', '')\n                WHEN '213077' THEN 'Chapel'\n                WHEN '213078' THEN 'Dining room'\n                WHEN '213079' THEN 'Dormitory'\n                WHEN '213080' THEN 'Education'\n                WHEN '213081' THEN 'Exercise yard'\n                WHEN '213082' THEN 'Gate'\n                WHEN '213083' THEN 'Gym'\n                WHEN '213084' THEN 'Health care centre'\n                WHEN '213085' THEN 'Kitchen'\n                WHEN '213086' THEN 'Office'\n                WHEN '213087' THEN 'Reception'\n                WHEN '213088' THEN 'Recess'\n                WHEN '213089' THEN 'Segregation unit'\n                WHEN '213090' THEN 'Special unit' || COALESCE(' (' || NULLIF(res.additional_information, '') || ')', '')\n                WHEN '213091' THEN 'Showers/changing room'\n                WHEN '213092' THEN 'Visits'\n                WHEN '213093' THEN 'Wing' || COALESCE(' (' || NULLIF(res.additional_information, '') || ')', '')\n                WHEN '213094' THEN 'Works department'\n                WHEN '213095' THEN 'Workshop' || COALESCE(' (' || NULLIF(res.additional_information, '') || ')', '')\n                WHEN '213096' THEN 'Within perimeter' || COALESCE(' (' || NULLIF(res.additional_information, '') || ')', '')\n                WHEN '213097' THEN 'Elsewhere' || COALESCE(' (' || NULLIF(res.additional_information, '') || ')', '')\n                WHEN '213098' THEN 'Funeral'\n                WHEN '213099' THEN 'Hospital outside (patient)'\n                WHEN '213100' THEN 'Hospital outside (visiting)'\n                WHEN '213101' THEN 'Outside working party' || COALESCE(' (' || NULLIF(res.additional_information, '') || ')', '')\n                WHEN '213102' THEN 'Sports field'\n                WHEN '213103' THEN 'Vehicle'\n                WHEN '213104' THEN 'Weddings'\n                WHEN '213105' THEN 'Magistrates court' || COALESCE(' (' || NULLIF(res.additional_information, '') || ')', '')\n                WHEN '213106' THEN 'Crown court' || COALESCE(' (' || NULLIF(res.additional_information, '') || ')', '')\n                WHEN '213107' THEN 'Induction/first night centre' || COALESCE(' (' || NULLIF(res.additional_information, '') || ')', '')\n                WHEN '213108' THEN 'Mail room'\n                WHEN '213109' THEN 'Vulnerable prisoners unit (VPU)' || COALESCE(' (' || NULLIF(res.additional_information, '') || ')', '')\n                WHEN '213110' THEN 'External roof' || COALESCE(' (' || NULLIF(res.additional_information, '') || ')', '')\n                -- ASSAULT_1 Q45134 (no comments on any response)\n                WHEN '182475' THEN 'Administration'\n                WHEN '182476' THEN 'Association area'\n                WHEN '182477' THEN 'Cell'\n                WHEN '182478' THEN 'Chapel'\n                WHEN '182479' THEN 'Crown court'\n                WHEN '182480' THEN 'Dining room'\n                WHEN '182481' THEN 'Dormitory'\n                WHEN '182482' THEN 'Education'\n                WHEN '182483' THEN 'Elsewhere'\n                WHEN '182484' THEN 'Exercise yard'\n                WHEN '182485' THEN 'Funeral'\n                WHEN '182486' THEN 'Gate'\n                WHEN '182487' THEN 'Gym'\n                WHEN '182488' THEN 'Health care centre'\n                WHEN '182489' THEN 'Hospital outside (patient)'\n                WHEN '182490' THEN 'Hospital outside (visiting)'\n                WHEN '182491' THEN 'Kitchen'\n                WHEN '182492' THEN 'Magistrates court'\n                WHEN '182493' THEN 'Office'\n                WHEN '182494' THEN 'Outside working party'\n                WHEN '182495' THEN 'Reception'\n                WHEN '182496' THEN 'Recess'\n                WHEN '182497' THEN 'Segregation unit'\n                WHEN '182498' THEN 'Showers/changing room'\n                WHEN '182499' THEN 'Special unit'\n                WHEN '182500' THEN 'Sports field'\n                WHEN '182501' THEN 'Vehicle'\n                WHEN '182502' THEN 'Visits'\n                WHEN '182503' THEN 'Weddings'\n                WHEN '182504' THEN 'Wing'\n                WHEN '182505' THEN 'Within perimeter'\n                WHEN '182506' THEN 'Works department'\n                WHEN '182507' THEN 'Workshop'\n                -- SELF_HARM_1 Q45051 (all have mandatory comment)\n                WHEN '182175' THEN 'Court cell' || COALESCE(' (' || NULLIF(res.additional_information, '') || ')', '')\n                WHEN '182176' THEN 'Detox unit' || COALESCE(' (' || NULLIF(res.additional_information, '') || ')', '')\n                WHEN '182177' THEN 'Health care centre' || COALESCE(' (' || NULLIF(res.additional_information, '') || ')', '')\n                WHEN '182178' THEN 'Indct''n/recp''n/1st nightcentre' || COALESCE(' (' || NULLIF(res.additional_information, '') || ')', '')\n                WHEN '182179' THEN 'Ordinary' || COALESCE(' (' || NULLIF(res.additional_information, '') || ')', '')\n                WHEN '182180' THEN 'Other' || COALESCE(' (' || NULLIF(res.additional_information, '') || ')', '')\n                WHEN '182181' THEN 'Prison escort vehicle' || COALESCE(' (' || NULLIF(res.additional_information, '') || ')', '')\n                WHEN '182182' THEN 'Segregation unit' || COALESCE(' (' || NULLIF(res.additional_information, '') || ')', '')\n                WHEN '182183' THEN 'VPU/other protected' || COALESCE(' (' || NULLIF(res.additional_information, '') || ')', '')\n                -- FIND_6 Q67181\n                WHEN '218712' THEN 'Administration'\n                WHEN '218713' THEN 'Association area' || COALESCE(' (' || NULLIF(res.additional_information, '') || ')', '')\n                WHEN '218714' THEN 'Cell' || COALESCE(' (' || NULLIF(res.additional_information, '') || ')', '')\n                WHEN '218715' THEN 'Chapel'\n                WHEN '218716' THEN 'Court'\n                WHEN '218717' THEN 'Dining room' || COALESCE(' (' || NULLIF(res.additional_information, '') || ')', '')\n                WHEN '218718' THEN 'Dormitory' || COALESCE(' (' || NULLIF(res.additional_information, '') || ')', '')\n                WHEN '218719' THEN 'Education'\n                WHEN '218720' THEN 'Exercise yard' || COALESCE(' (' || NULLIF(res.additional_information, '') || ')', '')\n                WHEN '218721' THEN 'Gate/gate lodge'\n                WHEN '218722' THEN 'Gym'\n                WHEN '218723' THEN 'Health care centre'\n                WHEN '218724' THEN 'Hospital outside (patient)'\n                WHEN '218725' THEN 'Hospital outside (visiting)'\n                WHEN '218726' THEN 'Induction/first night centre'\n                WHEN '218727' THEN 'Kitchen'\n                WHEN '218728' THEN 'Mail room'\n                WHEN '218729' THEN 'Office'\n                WHEN '218730' THEN 'Outside working party'\n                WHEN '218731' THEN 'Reception'\n                WHEN '218732' THEN 'Recess/ roof void'\n                WHEN '218733' THEN 'Segregation unit' || COALESCE(' (' || NULLIF(res.additional_information, '') || ')', '')\n                WHEN '218734' THEN 'Showers/changing room' || COALESCE(' (' || NULLIF(res.additional_information, '') || ')', '')\n                WHEN '218735' THEN 'Vehicle used for court/transfer'\n                WHEN '218736' THEN 'Visits'\n                WHEN '218737' THEN 'Vulnerable prisoners unit (VPU)' || COALESCE(' (' || NULLIF(res.additional_information, '') || ')', '')\n                WHEN '218738' THEN 'Wing' || COALESCE(' (' || NULLIF(res.additional_information, '') || ')', '')\n                WHEN '218739' THEN 'Workshop' || COALESCE(' (' || NULLIF(res.additional_information, '') || ')', '')\n                WHEN '218740' THEN 'Other' || COALESCE(' (' || NULLIF(res.additional_information, '') || ')', '')\n                -- DISORDER_2 Q63182 (all no comment except 214729)\n                WHEN '214694' THEN 'Administration'\n                WHEN '214695' THEN 'Association area'\n                WHEN '214696' THEN 'Cell'\n                WHEN '214697' THEN 'Chapel'\n                WHEN '214698' THEN 'Crown court'\n                WHEN '214699' THEN 'Dining room'\n                WHEN '214700' THEN 'Dormitory'\n                WHEN '214701' THEN 'Education'\n                WHEN '214702' THEN 'Exercise yard'\n                WHEN '214703' THEN 'External roof'\n                WHEN '214704' THEN 'Funeral'\n                WHEN '214705' THEN 'Gate'\n                WHEN '214706' THEN 'Gym'\n                WHEN '214707' THEN 'Health care centre'\n                WHEN '214708' THEN 'Hospital outside (patient)'\n                WHEN '214709' THEN 'Hospital outside (visiting)'\n                WHEN '214710' THEN 'Induction/1st night centre'\n                WHEN '214711' THEN 'Kitchen'\n                WHEN '214712' THEN 'Magistrates court'\n                WHEN '214713' THEN 'Office'\n                WHEN '214714' THEN 'Outside working party'\n                WHEN '214715' THEN 'Reception'\n                WHEN '214716' THEN 'Recess'\n                WHEN '214717' THEN 'Segregation unit'\n                WHEN '214718' THEN 'Showers/changing room'\n                WHEN '214719' THEN 'Special unit'\n                WHEN '214720' THEN 'Sports field'\n                WHEN '214721' THEN 'Vehicle'\n                WHEN '214722' THEN 'Visits'\n                WHEN '214723' THEN 'Vulnerable prisoners unit'\n                WHEN '214724' THEN 'Weddings'\n                WHEN '214725' THEN 'Wing'\n                WHEN '214726' THEN 'Within perimeter'\n                WHEN '214727' THEN 'Works department'\n                WHEN '214728' THEN 'Workshop'\n                WHEN '214729' THEN 'Other' || COALESCE(' (' || NULLIF(res.additional_information, '') || ')', '')\n                -- DISORDER_1 Q49182 (inactive, no comment except 194703)\n                WHEN '194695' THEN 'Administration'\n                WHEN '194696' THEN 'Association area'\n                WHEN '194697' THEN 'Cell'\n                WHEN '194698' THEN 'Chapel'\n                WHEN '194699' THEN 'Crown court'\n                WHEN '194700' THEN 'Dining room'\n                WHEN '194701' THEN 'Dormitory'\n                WHEN '194702' THEN 'Education'\n                WHEN '194703' THEN 'Elsewhere' || COALESCE(' (' || NULLIF(res.additional_information, '') || ')', '')\n                WHEN '194704' THEN 'Exercise yard'\n                WHEN '194705' THEN 'Funeral'\n                WHEN '194706' THEN 'Gate'\n                WHEN '194707' THEN 'Gym'\n                WHEN '194708' THEN 'Health care centre'\n                WHEN '194709' THEN 'Hospital outside (patient)'\n                WHEN '194710' THEN 'Hospital outside (visiting)'\n                WHEN '194711' THEN 'Kitchen'\n                WHEN '194712' THEN 'Magistrates court'\n                WHEN '194713' THEN 'Office'\n                WHEN '194714' THEN 'Outside working party'\n                WHEN '194715' THEN 'Reception'\n                WHEN '194716' THEN 'Recess'\n                WHEN '194717' THEN 'Segregation unit'\n                WHEN '194718' THEN 'Showers/changing room'\n                WHEN '194719' THEN 'Special unit'\n                WHEN '194720' THEN 'Sports field'\n                WHEN '194721' THEN 'Vehicle'\n                WHEN '194722' THEN 'Visits'\n                WHEN '194723' THEN 'Weddings'\n                WHEN '194724' THEN 'Wing'\n                WHEN '194725' THEN 'Within perimeter'\n                WHEN '194726' THEN 'Works department'\n                WHEN '194727' THEN 'Workshop'\n                WHEN '194728' THEN 'Induction/1st night centre'\n                WHEN '194729' THEN 'External roof'\n                WHEN '194730' THEN 'Vulnerable prisoners unit'\n                -- FIRE_1 Q44194\n                WHEN '179121' THEN 'Administration'\n                WHEN '179122' THEN 'Association area'\n                WHEN '179123' THEN 'Cell' || COALESCE(' (' || NULLIF(res.additional_information, '') || ')', '')\n                WHEN '179124' THEN 'Chapel'\n                WHEN '179126' THEN 'Dining room'\n                WHEN '179127' THEN 'Dormitory'\n                WHEN '179128' THEN 'Education'\n                WHEN '179130' THEN 'Exercise yard'\n                WHEN '179132' THEN 'Gate'\n                WHEN '179133' THEN 'Gym'\n                WHEN '179134' THEN 'Health care centre'\n                WHEN '179137' THEN 'Kitchen'\n                WHEN '179139' THEN 'Office'\n                WHEN '179141' THEN 'Reception'\n                WHEN '179142' THEN 'Recess'\n                WHEN '179143' THEN 'Segregation unit'\n                WHEN '179145' THEN 'Special unit'\n                WHEN '179144' THEN 'Showers/changing room'\n                WHEN '179148' THEN 'Visits'\n                WHEN '179150' THEN 'Wing'\n                WHEN '179152' THEN 'Works department'\n                WHEN '179153' THEN 'Workshop'\n                WHEN '179151' THEN 'Within perimeter'\n                WHEN '179129' THEN 'Elsewhere' || COALESCE(' (' || NULLIF(res.additional_information, '') || ')', '')\n                -- DIRTY_PROTEST_1 Q100000\n                WHEN '100001' THEN 'Ordinary cell' || COALESCE(' (' || NULLIF(res.additional_information, '') || ')', '')\n                WHEN '100002' THEN 'Specialist cell/unit' || COALESCE(' (' || NULLIF(res.additional_information, '') || ')', '')\n                WHEN '100003' THEN 'Shower/changing room' || COALESCE(' (' || NULLIF(res.additional_information, '') || ')', '')\n                WHEN '100004' THEN 'Other location within prison' || COALESCE(' (' || NULLIF(res.additional_information, '') || ')', '')\n                WHEN '100005' THEN 'Crown/magistrates court'\n                WHEN '100006' THEN 'Court cell'\n                WHEN '100007' THEN 'Vehicle' || COALESCE(' (' || NULLIF(res.additional_information, '') || ')', '')\n                -- DEATH_PRISONER_1 Q44366\n                WHEN '179724' THEN 'Single cell: ordinary location'\n                WHEN '179725' THEN 'Single cell: segregation unit'\n                WHEN '179723' THEN 'Shared cell: ordinary location'\n                WHEN '179727' THEN 'Special cell: segregation unit'\n                WHEN '179726' THEN 'Single cell: health care centre'\n                WHEN '179729' THEN 'Ward: health care centre'\n                WHEN '179728' THEN 'Unfurnished room: health care centre'\n                WHEN '179722' THEN 'Protective room: health care centre'\n                WHEN '179721' THEN 'Other' || COALESCE(' (' || NULLIF(res.additional_information, '') || ')', '')\n                -- DEATH_OTHER_1 Q44751 (single freetext response)\n                WHEN '181107' THEN NULLIF(res.additional_information, '')\n                -- ABSCOND_1 Q44717\n                WHEN '180993' THEN 'From establishment'\n                WHEN '180995' THEN 'Supervised outside party'\n                WHEN '180996' THEN 'Unsupervised outside party'\n                WHEN '180994' THEN 'Other' || COALESCE(' (' || NULLIF(res.additional_information, '') || ')', '')\n                -- ESCAPE_FROM_ESCORT_1 Q45112\n                WHEN '182389' THEN 'Vehicle en route to venue'\n                WHEN '182388' THEN 'Vehicle en route from venue'\n                WHEN '182387' THEN 'Leaving vehicle (debussing)'\n                WHEN '182386' THEN 'Entering vehicle (embussing)'\n                WHEN '182398' THEN 'Unscheduled stop'\n                WHEN '182390' THEN 'Cell at court'\n                WHEN '182391' THEN 'Court cells area'\n                WHEN '182393' THEN 'Court visits area'\n                WHEN '182392' THEN 'Court dock'\n                WHEN '182396' THEN 'Hospital ward/room'\n                WHEN '182394' THEN 'Hospital treatment room'\n                WHEN '182395' THEN 'Hospital waiting area'\n                WHEN '182397' THEN 'Other' || COALESCE(' (' || NULLIF(res.additional_information, '') || ')', '')\n                -- ESCAPE_FROM_PRISON_1 Q45032\n                WHEN '182064' THEN 'Sports field'\n                WHEN '182065' THEN 'Cell' || COALESCE(' (' || NULLIF(res.additional_information, '') || ')', '')\n                WHEN '182066' THEN 'Visits'\n                WHEN '182079' THEN 'Wing/houseblock'\n                WHEN '182069' THEN 'Dormitory'\n                WHEN '182074' THEN 'Health care centre'\n                WHEN '182068' THEN 'Chapel'\n                WHEN '182075' THEN 'Kitchen'\n                WHEN '182070' THEN 'Education/library'\n                WHEN '182081' THEN 'Workshop'\n                WHEN '182078' THEN 'Stores'\n                WHEN '182067' THEN 'Administration'\n                WHEN '182073' THEN 'Gymnasium'\n                WHEN '182077' THEN 'Reception'\n                WHEN '182080' THEN 'Works department'\n                WHEN '182071' THEN 'Exercise yard'\n                WHEN '182076' THEN 'Other secure area' || COALESCE(' (' || NULLIF(res.additional_information, '') || ')', '')\n                WHEN '182072' THEN 'Grounds with no access to external perimeter'\n                WHEN '182082' THEN 'Grounds with access to external perimeter'\n                -- ATTEMPTED_ESCAPE_FROM_ESCORT_1 Q44496\n                WHEN '180197' THEN 'Vehicle en route to venue'\n                WHEN '180196' THEN 'Vehicle en route from venue'\n                WHEN '180195' THEN 'Leaving vehicle (debussing)'\n                WHEN '180194' THEN 'Entering vehicle (embussing)'\n                WHEN '180206' THEN 'Unscheduled stop'\n                WHEN '180198' THEN 'Cell at court'\n                WHEN '180199' THEN 'Court cells area'\n                WHEN '180201' THEN 'Court visits area'\n                WHEN '180200' THEN 'Court dock'\n                WHEN '180204' THEN 'Hospital ward/room'\n                WHEN '180202' THEN 'Hospital treatment room'\n                WHEN '180203' THEN 'Hospital waiting area'\n                WHEN '180205' THEN 'Other' || COALESCE(' (' || NULLIF(res.additional_information, '') || ')', '')\n                -- ATTEMPTED_ESCAPE_FROM_PRISON_1 Q44594\n                WHEN '180572' THEN 'Sports field'\n                WHEN '180573' THEN 'Cell' || COALESCE(' (' || NULLIF(res.additional_information, '') || ')', '')\n                WHEN '180574' THEN 'Visits'\n                WHEN '180588' THEN 'Wing/houseblock'\n                WHEN '180577' THEN 'Dormitory'\n                WHEN '180583' THEN 'Health care centre'\n                WHEN '180576' THEN 'Chapel'\n                WHEN '180584' THEN 'Kitchen'\n                WHEN '180578' THEN 'Education/library'\n                WHEN '180590' THEN 'Workshop'\n                WHEN '180587' THEN 'Stores'\n                WHEN '180575' THEN 'Administration'\n                WHEN '180582' THEN 'Gymnasium'\n                WHEN '180586' THEN 'Reception'\n                WHEN '180589' THEN 'Works department'\n                WHEN '180579' THEN 'Exercise yard'\n                WHEN '180585' THEN 'Other secure area' || COALESCE(' (' || NULLIF(res.additional_information, '') || ')', '')\n                WHEN '180581' THEN 'Grounds with no access to external perimeter'\n                WHEN '180580' THEN 'Grounds with access to external perimeter'\n                -- BREACH_OF_SECURITY_1 Q44946\n                WHEN '181777' THEN 'Inside prison' || COALESCE(' (' || NULLIF(res.additional_information, '') || ')', '')\n                WHEN '181778' THEN 'Outside prison'\n                -- BOMB_1 Q45178\n                WHEN '182651' THEN 'Administration'\n                WHEN '182652' THEN 'Association area'\n                WHEN '182653' THEN 'Cell'\n                WHEN '182654' THEN 'Chapel'\n                WHEN '182655' THEN 'Crown court'\n                WHEN '182656' THEN 'Dining room'\n                WHEN '182657' THEN 'Dormitory'\n                WHEN '182658' THEN 'Education'\n                WHEN '182659' THEN 'Elsewhere' || COALESCE(' (' || NULLIF(res.additional_information, '') || ')', '')\n                WHEN '182660' THEN 'Exercise yard'\n                WHEN '182661' THEN 'Funeral'\n                WHEN '182662' THEN 'Gate'\n                WHEN '182663' THEN 'Gym'\n                WHEN '182664' THEN 'Health care centre'\n                WHEN '182665' THEN 'Hospital outside (patient)'\n                WHEN '182666' THEN 'Hospital outside (visiting)'\n                WHEN '182667' THEN 'Kitchen'\n                WHEN '182668' THEN 'Magistrates court'\n                WHEN '182669' THEN 'Office'\n                WHEN '182670' THEN 'Outside working party'\n                WHEN '182671' THEN 'Reception'\n                WHEN '182672' THEN 'Recess'\n                WHEN '182673' THEN 'Segregation unit'\n                WHEN '182674' THEN 'Showers/changing room'\n                WHEN '182675' THEN 'Special unit'\n                WHEN '182676' THEN 'Sports field'\n                WHEN '182677' THEN 'Vehicle'\n                WHEN '182678' THEN 'Visits'\n                WHEN '182679' THEN 'Weddings'\n                WHEN '182680' THEN 'Wing'\n                WHEN '182681' THEN 'Within perimeter'\n                WHEN '182682' THEN 'Works department'\n                WHEN '182683' THEN 'Workshop'\n                -- RELEASE_IN_ERROR_1 Q45180 (multipleAnswers, all mandatory comment)\n                WHEN '183026' THEN 'Establishment' || COALESCE(' (' || NULLIF(res.additional_information, '') || ')', '')\n                WHEN '183027' THEN 'Court' || COALESCE(' (' || NULLIF(res.additional_information, '') || ')', '')\n                WHEN '183028' THEN 'Other' || COALESCE(' (' || NULLIF(res.additional_information, '') || ')', '')\n                -- BARRICADE_1 Q44532 (inactive type, legacy)\n                WHEN '180354' THEN 'Administration'\n                WHEN '180355' THEN 'Association area'\n                WHEN '180356' THEN 'Cell'\n                WHEN '180357' THEN 'Chapel'\n                WHEN '180358' THEN 'Crown court'\n                WHEN '180359' THEN 'Dining room'\n                WHEN '180360' THEN 'Dormitory'\n                WHEN '180361' THEN 'Education'\n                WHEN '180362' THEN 'Elsewhere' || COALESCE(' (' || NULLIF(res.additional_information, '') || ')', '')\n                WHEN '180363' THEN 'Exercise yard'\n                WHEN '180364' THEN 'Funeral'\n                WHEN '180365' THEN 'Gate'\n                WHEN '180366' THEN 'Gym'\n                WHEN '180367' THEN 'Health care centre'\n                WHEN '180368' THEN 'Hospital outside (patient)'\n                WHEN '180369' THEN 'Hospital outside (visiting)'\n                WHEN '180370' THEN 'Kitchen'\n                WHEN '180371' THEN 'Magistrates court'\n                WHEN '180372' THEN 'Office'\n                WHEN '180373' THEN 'Outside working party'\n                WHEN '180374' THEN 'Reception'\n                WHEN '180375' THEN 'Recess'\n                WHEN '180376' THEN 'Segregation unit'\n                WHEN '180377' THEN 'Showers/changing room'\n                WHEN '180378' THEN 'Special unit'\n                WHEN '180379' THEN 'Sports field'\n                WHEN '180380' THEN 'Vehicle'\n                WHEN '180381' THEN 'Visits'\n                WHEN '180382' THEN 'Weddings'\n                WHEN '180383' THEN 'Wing'\n                WHEN '180384' THEN 'Within perimeter'\n                WHEN '180385' THEN 'Works department'\n                WHEN '180386' THEN 'Workshop'\n                -- HOSTAGE_1 Q44463 (inactive type, legacy)\n                WHEN '180034' THEN 'Administration'\n                WHEN '180035' THEN 'Association area'\n                WHEN '180036' THEN 'Cell'\n                WHEN '180037' THEN 'Chapel'\n                WHEN '180038' THEN 'Crown court'\n                WHEN '180039' THEN 'Dining room'\n                WHEN '180040' THEN 'Dormitory'\n                WHEN '180041' THEN 'Education'\n                WHEN '180042' THEN 'Elsewhere' || COALESCE(' (' || NULLIF(res.additional_information, '') || ')', '')\n                WHEN '180043' THEN 'Exercise yard'\n                WHEN '180044' THEN 'Funeral'\n                WHEN '180045' THEN 'Gate'\n                WHEN '180046' THEN 'Gym'\n                WHEN '180047' THEN 'Health care centre'\n                WHEN '180048' THEN 'Hospital outside (patient)'\n                WHEN '180049' THEN 'Hospital outside (visiting)'\n                WHEN '180050' THEN 'Kitchen'\n                WHEN '180051' THEN 'Magistrates court'\n                WHEN '180052' THEN 'Office'\n                WHEN '180053' THEN 'Outside working party'\n                WHEN '180054' THEN 'Reception'\n                WHEN '180055' THEN 'Recess'\n                WHEN '180056' THEN 'Segregation unit'\n                WHEN '180057' THEN 'Showers/changing room'\n                WHEN '180058' THEN 'Special unit'\n                WHEN '180059' THEN 'Sports field'\n                WHEN '180060' THEN 'Vehicle'\n                WHEN '180061' THEN 'Visits'\n                WHEN '180062' THEN 'Weddings'\n                WHEN '180063' THEN 'Wing'\n                WHEN '180064' THEN 'Within perimeter'\n                WHEN '180065' THEN 'Works department'\n                WHEN '180066' THEN 'Workshop'\n                -- CONCERTED_INDISCIPLINE_1 Q44304 (inactive type, legacy)\n                WHEN '179481' THEN 'Administration'\n                WHEN '179482' THEN 'Association area'\n                WHEN '179483' THEN 'Cell'\n                WHEN '179484' THEN 'Chapel'\n                WHEN '179485' THEN 'Crown court'\n                WHEN '179486' THEN 'Dining room'\n                WHEN '179487' THEN 'Dormitory'\n                WHEN '179488' THEN 'Education'\n                WHEN '179489' THEN 'Elsewhere' || COALESCE(' (' || NULLIF(res.additional_information, '') || ')', '')\n                WHEN '179490' THEN 'Exercise yard'\n                WHEN '179491' THEN 'Funeral'\n                WHEN '179492' THEN 'Gate'\n                WHEN '179493' THEN 'Gym'\n                WHEN '179494' THEN 'Health care centre'\n                WHEN '179495' THEN 'Hospital outside (patient)'\n                WHEN '179496' THEN 'Hospital outside (visiting)'\n                WHEN '179497' THEN 'Kitchen'\n                WHEN '179498' THEN 'Magistrates court'\n                WHEN '179499' THEN 'Office'\n                WHEN '179500' THEN 'Outside working party'\n                WHEN '179501' THEN 'Reception'\n                WHEN '179502' THEN 'Recess'\n                WHEN '179503' THEN 'Segregation unit'\n                WHEN '179504' THEN 'Showers/changing room'\n                WHEN '179505' THEN 'Special unit'\n                WHEN '179506' THEN 'Sports field'\n                WHEN '179507' THEN 'Vehicle'\n                WHEN '179508' THEN 'Visits'\n                WHEN '179509' THEN 'Weddings'\n                WHEN '179510' THEN 'Wing'\n                WHEN '179511' THEN 'Within perimeter'\n                WHEN '179512' THEN 'Works department'\n                WHEN '179513' THEN 'Workshop'\n                -- INCIDENT_AT_HEIGHT_1 Q44927 (inactive type, legacy)\n                WHEN '181684' THEN 'Administration'\n                WHEN '181685' THEN 'Association area'\n                WHEN '181686' THEN 'Cell'\n                WHEN '181687' THEN 'Chapel'\n                WHEN '181688' THEN 'Crown court'\n                WHEN '181689' THEN 'Dining room'\n                WHEN '181690' THEN 'Dormitory'\n                WHEN '181691' THEN 'Education'\n                WHEN '181692' THEN 'Elsewhere' || COALESCE(' (' || NULLIF(res.additional_information, '') || ')', '')\n                WHEN '181693' THEN 'Exercise yard'\n                WHEN '181694' THEN 'Funeral'\n                WHEN '181695' THEN 'Gate'\n                WHEN '181696' THEN 'Gym'\n                WHEN '181697' THEN 'Health care centre'\n                WHEN '181698' THEN 'Hospital outside (patient)'\n                WHEN '181699' THEN 'Hospital outside (visiting)'\n                WHEN '181700' THEN 'Kitchen'\n                WHEN '181701' THEN 'Magistrates court'\n                WHEN '181702' THEN 'Office'\n                WHEN '181703' THEN 'Outside working party'\n                WHEN '181704' THEN 'Reception'\n                WHEN '181705' THEN 'Recess'\n                WHEN '181706' THEN 'Segregation unit'\n                WHEN '181707' THEN 'Showers/changing room'\n                WHEN '181708' THEN 'Special unit'\n                WHEN '181709' THEN 'Sports field'\n                WHEN '181710' THEN 'Vehicle'\n                WHEN '181711' THEN 'Visits'\n                WHEN '181712' THEN 'Weddings'\n                WHEN '181713' THEN 'Wing'\n                WHEN '181714' THEN 'Within perimeter'\n                WHEN '181715' THEN 'Works department'\n                WHEN '181716' THEN 'Workshop'\n            END\n        END) AS incident_location\n\n    FROM prisons.incidentreporting_question q\n             JOIN prisons.incidentreporting_response res ON res.question_id = q.id\n    GROUP BY 1\n)\n\nSELECT\n    r.id,\n    r.report_reference,\n    r.location,\n    p.name AS location_name,\n    al.noms_region_code AS region_code,\n    area.description AS region_name,\n    ctf.code AS type,\n    ct.description AS type_description,\n\n    -- incident_subtype logic refactored\n    CASE\n        WHEN ctf.code = 'ASSAULT' THEN qa.assault_subtype\n        WHEN ctf.code = 'BARRICADE' THEN 'Barricade'\n        WHEN ctf.code = 'CONCERTED_INDISCIPLINE' THEN 'Concerted Indiscipline'\n        WHEN ctf.code = 'HOSTAGE' THEN 'Hostage'\n        WHEN ctf.code = 'INCIDENT_AT_HEIGHT' THEN 'Incident at Height'\n        WHEN ctf.code = 'DISORDER' THEN 'Disorder'\n        WHEN ctf.code = 'FIND' THEN\n            COALESCE(qa.find_category_new,\n                     CASE\n                         WHEN (qa.found_drug + qa.found_mobile + qa.found_alcohol) > 1 THEN 'Multiple types'\n                         WHEN qa.found_drug = 1 THEN 'Drug / drug equipment'\n                         WHEN qa.found_mobile = 1 THEN 'Mobile phone / mobile related item'\n                         WHEN qa.found_alcohol = 1 THEN 'Alcohol / hooch / distilling equipment'\n                         END\n            )\n        END AS incident_subtype,\n\n    r.status,\n    cs.description AS status_description,\n    r.incident_date_and_time,\n    r.reported_by,\n    INITCAP(pi.first_name) AS first_name,\n    INITCAP(pi.last_name) AS last_name,\n    pi.prisoner_number,\n    cpr.description AS prisoner_role,\n    pi.comment AS prisoner_comment,\n\n    -- Assault Extra Info\n    CASE WHEN ctf.code = 'ASSAULT' THEN COALESCE(qa.is_serious, 'N') END AS serious_injury,\n    CASE WHEN ctf.code = 'ASSAULT' THEN COALESCE(qa.is_concussion, 'N') END AS concussion_treatment,\n    qa.hospital_admission_type,\n    CASE WHEN ctf.code = 'ASSAULT' THEN COALESCE(qa.is_sexual, 'N') END AS sexual_assault,\n    CASE WHEN ctf.code = 'ASSAULT' THEN COALESCE(qa.is_minor, 'N') END AS minor_assault,\n    CASE WHEN ctf.code = 'ASSAULT' THEN COALESCE(qa.is_spitting, 'N') END AS spitting,\n    qa.assault_reason,\n\n    -- Self-Harm Extra Info\n    CASE WHEN ctf.code = 'SELF_HARM' THEN COALESCE(qa.is_cutting, 'N') END AS cutting,\n    CASE WHEN ctf.code = 'SELF_HARM' THEN COALESCE(qa.is_ligature, 'N') END AS strangulation_or_hanging,\n    CASE WHEN ctf.code = 'SELF_HARM' THEN COALESCE(qa.is_burning, 'N') END AS burning,\n\n    -- Finds Extra Info\n    CASE WHEN ctf.code = 'FIND' THEN\n        NULLIF(REGEXP_REPLACE(\n            CASE WHEN COALESCE(qa.f6m_alcohol, 0) = 1 OR COALESCE(qa.found_alcohol, 0) = 1 THEN 'Alcohol, ' ELSE '' END ||\n            CASE WHEN COALESCE(qa.f6m_drugs, 0) = 1 OR COALESCE(qa.found_drug, 0) = 1 THEN 'Drugs, ' ELSE '' END ||\n            CASE WHEN COALESCE(qa.f6m_mobile, 0) = 1 OR COALESCE(qa.found_mobile, 0) = 1 THEN 'Mobile phone, ' ELSE '' END ||\n            CASE WHEN COALESCE(qa.f6m_sim, 0) = 1 THEN 'SIM card, ' ELSE '' END ||\n            CASE WHEN COALESCE(qa.f6m_memory, 0) = 1 THEN 'Memory card, ' ELSE '' END ||\n            CASE WHEN COALESCE(qa.f6m_digital, 0) = 1 THEN 'Digital, ' ELSE '' END ||\n            CASE WHEN COALESCE(qa.f6m_tobacco, 0) = 1 THEN 'Tobacco, ' ELSE '' END ||\n            CASE WHEN COALESCE(qa.f6m_weapon, 0) = 1 THEN 'Weapon, ' ELSE '' END\n        , ',\\\\s*$', ''), '')\n    END AS finds_detail,\n\n    qa.incident_location,\n    -- Incident summary: key facts for the incident type in plain words\n    CASE\n        WHEN ctf.code = 'ASSAULT' THEN\n            NULLIF(REGEXP_REPLACE(\n                CASE WHEN COALESCE(qa.is_serious, 'N') = 'Y' THEN 'Serious injury, ' ELSE '' END ||\n                CASE WHEN COALESCE(qa.is_sexual, 'N') = 'Y' THEN 'Sexual assault, ' ELSE '' END ||\n                CASE WHEN COALESCE(qa.is_minor, 'N') = 'Y' THEN 'Minor assault, ' ELSE '' END ||\n                CASE WHEN COALESCE(qa.is_spitting, 'N') = 'Y' THEN 'Spitting, ' ELSE '' END ||\n                CASE WHEN COALESCE(qa.is_concussion, 'N') = 'Y' THEN 'Concussion treatment, ' ELSE '' END ||\n                CASE WHEN qa.hospital_admission_type IS NOT NULL THEN qa.hospital_admission_type || ', ' ELSE '' END\n            , ',\\\\s*$', ''), '')\n        WHEN ctf.code = 'SELF_HARM' THEN\n            NULLIF(REGEXP_REPLACE(\n                CASE WHEN COALESCE(qa.is_cutting, 'N') = 'Y' THEN 'Cutting, ' ELSE '' END ||\n                CASE WHEN COALESCE(qa.is_ligature, 'N') = 'Y' THEN 'Strangulation or hanging, ' ELSE '' END ||\n                CASE WHEN COALESCE(qa.is_burning, 'N') = 'Y' THEN 'Burning, ' ELSE '' END\n            , ',\\\\s*$', ''), '')\n        WHEN ctf.code = 'FIND' THEN\n            NULLIF(REGEXP_REPLACE(\n                CASE WHEN COALESCE(qa.f6m_alcohol, 0) = 1 OR COALESCE(qa.found_alcohol, 0) = 1 THEN 'Alcohol, ' ELSE '' END ||\n                CASE WHEN COALESCE(qa.f6m_drugs, 0) = 1 OR COALESCE(qa.found_drug, 0) = 1 THEN 'Drugs, ' ELSE '' END ||\n                CASE WHEN COALESCE(qa.f6m_mobile, 0) = 1 OR COALESCE(qa.found_mobile, 0) = 1 THEN 'Mobile phone, ' ELSE '' END ||\n                CASE WHEN COALESCE(qa.f6m_sim, 0) = 1 THEN 'SIM card, ' ELSE '' END ||\n                CASE WHEN COALESCE(qa.f6m_memory, 0) = 1 THEN 'Memory card, ' ELSE '' END ||\n                CASE WHEN COALESCE(qa.f6m_digital, 0) = 1 THEN 'Digital, ' ELSE '' END ||\n                CASE WHEN COALESCE(qa.f6m_tobacco, 0) = 1 THEN 'Tobacco, ' ELSE '' END ||\n                CASE WHEN COALESCE(qa.f6m_weapon, 0) = 1 THEN 'Weapon, ' ELSE '' END\n            , ',\\\\s*$', ''), '')\n    END AS incident_summary\n\nFROM prisons.incidentreporting_prisoner_involvement pi\n         JOIN prisons.incidentreporting_report r ON r.id = pi.report_id\n         JOIN prisons.incidentreporting_constant_status cs ON r.status = cs.code\n         JOIN prisons.incidentreporting_constant_type ct ON r.type = ct.code\n         JOIN prisons.incidentreporting_constant_type_family ctf ON ctf.code = ct.family_code\n         JOIN prisons.incidentreporting_constant_prisoner_role cpr ON cpr.code = pi.prisoner_role\n         JOIN prisons.prisonregister_prison p ON p.prison_id = r.location\n         JOIN prisons.nomis_agency_locations al ON al.agy_loc_id = p.prison_id\n         LEFT JOIN prisons.nomis_areas area ON area.area_class = 'REGION' AND area.area_code = al.noms_region_code\n         LEFT JOIN qa_pivoted qa ON qa.report_id = r.id\n\nWHERE r.status NOT IN ('DUPLICATE', 'NOT_REPORTABLE', 'DRAFT')",
+      "schema": {
+        "field": [
+          {
+            "name": "id",
+            "type": "string"
+          },
+          {
+            "name": "report_reference",
+            "type": "string"
+          },
+          {
+            "name": "type",
+            "type": "string",
+            "filter": {
+              "type": "multiselect",
+              "dynamicoptions": {
+                "maximumOptions": 60,
+                "returnAsStaticOptions": true,
+                "dataset": "types",
+                "name": "code",
+                "display": "description"
+              }
+            }
+          },
+          {
+            "name": "type_description",
+            "type": "string"
+          },
+          {
+            "name": "status",
+            "type": "string",
+            "filter": {
+              "type": "multiselect",
+              "interactive": true,
+              "dynamicoptions": {
+                "maximumOptions": 20,
+                "returnAsStaticOptions": true,
+                "dataset": "status",
+                "name": "code",
+                "display": "description"
+              }
+            }
+          },
+          {
+            "name": "status_description",
+            "type": "string"
+          },
+          {
+            "name": "incident_date_and_time",
+            "type": "datetime"
+          },
+          {
+            "name": "reported_by",
+            "type": "string"
+          },
+          {
+            "name": "first_name",
+            "type": "string"
+          },
+          {
+            "name": "last_name",
+            "type": "string"
+          },
+          {
+            "name": "prisoner_number",
+            "type": "string"
+          },
+          {
+            "name": "prisoner_role",
+            "type": "string"
+          },
+          {
+            "name": "prisoner_comment",
+            "type": "string"
+          },
+          {
+            "name": "location",
+            "type": "string"
+          },
+          {
+            "name": "location_name",
+            "type": "string"
+          },
+          {
+            "name": "region_code",
+            "type": "string"
+          },
+          {
+            "name": "region_name",
+            "type": "string"
+          },
+          {
+            "name": "incident_subtype",
+            "type": "string"
+          },
+          {
+            "name": "serious_injury",
+            "type": "string"
+          },
+          {
+            "name": "concussion_treatment",
+            "type": "string"
+          },
+          {
+            "name": "hospital_admission_type",
+            "type": "string"
+          },
+          {
+            "name": "sexual_assault",
+            "type": "string"
+          },
+          {
+            "name": "minor_assault",
+            "type": "string"
+          },
+          {
+            "name": "spitting",
+            "type": "string"
+          },
+          {
+            "name": "assault_reason",
+            "type": "string"
+          },
+          {
+            "name": "cutting",
+            "type": "string"
+          },
+          {
+            "name": "strangulation_or_hanging",
+            "type": "string"
+          },
+          {
+            "name": "burning",
+            "type": "string"
+          },
+          {
+            "name": "finds_detail",
+            "type": "string"
+          },
+          {
+            "name": "incident_location",
+            "type": "string"
+          },
+          {
+            "name": "incident_summary",
             "type": "string"
           }
         ]
@@ -2128,6 +2284,387 @@
             "defaultsort": true,
             "sortdirection": "desc",
             "formula": "make_url('https://incident-reporting-${env}.hmpps.service.justice.gov.uk/reports?searchID=${prisoner_number}',${total_incidents},TRUE)"
+          }
+        ]
+      },
+      "destination": []
+    },
+    {
+      "id": "prisoner-incident-detail",
+      "name": "Prisoner Involvement in Incidents: Establishment Level",
+      "description": "Shows each prisoner involved in a reported incident alongside their role, any comments recorded against them, and the where the incident took place. For key incident types, structured Q&A detail is surfaced as additional columns: assault severity flags (serious, sexual, minor, spitting, concussion treatment, hospital admission, and reason); self-harm method flags (cutting, strangulation/hanging, burning); and for finds, a comma-separated list of items identified.",
+      "version": "1.0.0",
+      "dataset": "$ref:prisoner-incident-detail",
+      "render": "HTML",
+      "feature": [
+        {
+          "type": "print"
+        }
+      ],
+      "metadata": {
+        "hints": [
+          "interactive"
+        ]
+      },
+      "specification": {
+        "template": "list",
+        "field": [
+          {
+            "name": "$ref:prisoner_number",
+            "display": "Prisoner number",
+            "sortable": true,
+            "formula": "make_url('https://prisoner-${env}.digital.prison.service.justice.gov.uk/prisoner/${prisoner_number}',${prisoner_number},TRUE)",
+            "visible": "true",
+            "defaultsort": false,
+            "filter": {
+              "type": "text"
+            }
+          },
+          {
+            "name": "$ref:last_name",
+            "formula": "${last_name}, ${first_name}",
+            "display": "Name",
+            "sortable": true,
+            "visible": "true",
+            "defaultsort": false
+          },
+          {
+            "name": "$ref:report_reference",
+            "display": "Incident number",
+            "sortable": true,
+            "formula": "make_url('https://incident-reporting-${env}.hmpps.service.justice.gov.uk/reports/${id}',${report_reference},TRUE)",
+            "visible": "true",
+            "defaultsort": false
+          },
+          {
+            "name": "$ref:incident_date_and_time",
+            "display": "Date of incident",
+            "formula": "format_date(${incident_date_and_time}, 'dd/MM/yyyy HH:mm')",
+            "sortable": true,
+            "visible": "true",
+            "defaultsort": true,
+            "sortdirection": "desc",
+            "filter": {
+              "type": "daterange",
+              "default": "today(-1,months) - today()"
+            }
+          },
+          {
+            "name": "$ref:type",
+            "display": "Type code",
+            "sortable": true,
+            "visible": "false",
+            "defaultsort": false
+          },
+          {
+            "name": "$ref:type_description",
+            "display": "Incident type",
+            "sortable": true,
+            "visible": "true",
+            "defaultsort": false
+          },
+          {
+            "name": "$ref:status",
+            "display": "Status code",
+            "sortable": false,
+            "visible": "false",
+            "defaultsort": false
+          },
+          {
+            "name": "$ref:status_description",
+            "display": "Incident status",
+            "sortable": true,
+            "visible": "true",
+            "defaultsort": false
+          },
+          {
+            "name": "$ref:location",
+            "display": "Location",
+            "sortable": true,
+            "visible": "false",
+            "defaultsort": false,
+            "filter": {
+              "type": "multiselect",
+              "mandatory": false,
+              "dynamicoptions": {
+                "maximumOptions": 140,
+                "returnAsStaticOptions": true,
+                "dataset": "prisons",
+                "name": "prison_id",
+                "display": "prison_name"
+              }
+            }
+          },
+          {
+            "name": "$ref:location_name",
+            "display": "Location name",
+            "sortable": true,
+            "visible": "true",
+            "defaultsort": false
+          },
+          {
+            "name": "$ref:incident_subtype",
+            "display": "Subtype",
+            "sortable": true,
+            "visible": "true",
+            "defaultsort": false,
+            "filter": {
+              "type": "multiselect",
+              "mandatory": false,
+              "staticoptions": [
+                {
+                  "name": "Prisoner on prisoner (PoP)",
+                  "display": "Prisoner on prisoner (PoP)"
+                },
+                {
+                  "name": "Prisoner on staff (PoS)",
+                  "display": "Prisoner on staff (PoS)"
+                },
+                {
+                  "name": "Prisoner on other",
+                  "display": "Prisoner on other"
+                },
+                {
+                  "name": "Other",
+                  "display": "Other"
+                }
+              ]
+            }
+          },
+          {
+            "name": "$ref:region_code",
+            "display": "Region",
+            "sortable": true,
+            "visible": "false",
+            "defaultsort": false,
+            "filter": {
+              "type": "multiselect",
+              "mandatory": false,
+              "dynamicoptions": {
+                "maximumOptions": 20,
+                "returnAsStaticOptions": true,
+                "dataset": "regionCodes",
+                "name": "code",
+                "display": "description"
+              }
+            }
+          },
+          {
+            "name": "$ref:region_name",
+            "display": "Region name",
+            "sortable": true,
+            "visible": "false",
+            "defaultsort": false
+          },
+          {
+            "name": "$ref:prisoner_role",
+            "display": "Prisoner role",
+            "sortable": false,
+            "visible": "true",
+            "defaultsort": false,
+            "filter": {
+              "type": "multiselect",
+              "mandatory": false,
+              "dynamicoptions": {
+                "maximumOptions": 20,
+                "returnAsStaticOptions": true,
+                "dataset": "prisoner_role",
+                "name": "description",
+                "display": "description"
+              }
+            }
+          },
+          {
+            "name": "$ref:incident_location",
+            "display": "Incident location",
+            "sortable": false,
+            "visible": "true",
+            "defaultsort": false
+          },
+          {
+            "name": "$ref:incident_summary",
+            "display": "Incident summary",
+            "sortable": false,
+            "visible": "true",
+            "defaultsort": false
+          },
+          {
+            "name": "$ref:prisoner_comment",
+            "display": "Prisoner comment",
+            "sortable": false,
+            "visible": "true",
+            "defaultsort": false
+          },
+          {
+            "name": "$ref:assault_reason",
+            "display": "Assault reason",
+            "sortable": false,
+            "visible": "true"
+          },
+          {
+            "name": "$ref:serious_injury",
+            "display": "Serious injury",
+            "sortable": false,
+            "visible": "false",
+            "filter": {
+              "type": "radio",
+              "staticoptions": [
+                {
+                  "name": "Y",
+                  "display": "Serious injury"
+                },
+                {
+                  "name": "N",
+                  "display": "Non serious injury"
+                }
+              ]
+            }
+          },
+          {
+            "name": "$ref:concussion_treatment",
+            "display": "Concussion treatment",
+            "sortable": false,
+            "visible": "false",
+            "filter": {
+              "type": "radio",
+              "staticoptions": [
+                {
+                  "name": "Y",
+                  "display": "Concussion"
+                },
+                {
+                  "name": "N",
+                  "display": "No concussion"
+                }
+              ]
+            }
+          },
+          {
+            "name": "$ref:hospital_admission_type",
+            "display": "Hospital admission type",
+            "sortable": false,
+            "visible": "true"
+          },
+          {
+            "name": "$ref:sexual_assault",
+            "display": "Sexual assault",
+            "sortable": false,
+            "visible": "false",
+            "filter": {
+              "type": "radio",
+              "staticoptions": [
+                {
+                  "name": "Y",
+                  "display": "Sexual assault"
+                },
+                {
+                  "name": "N",
+                  "display": "Non-sexual assault"
+                }
+              ]
+            }
+          },
+          {
+            "name": "$ref:minor_assault",
+            "display": "Minor assault",
+            "sortable": false,
+            "visible": "false",
+            "filter": {
+              "type": "radio",
+              "staticoptions": [
+                {
+                  "name": "Y",
+                  "display": "Minor assault"
+                },
+                {
+                  "name": "N",
+                  "display": "Not a minor assault"
+                }
+              ]
+            }
+          },
+          {
+            "name": "$ref:spitting",
+            "display": "Spitting",
+            "sortable": false,
+            "visible": "false",
+            "filter": {
+              "type": "radio",
+              "staticoptions": [
+                {
+                  "name": "Y",
+                  "display": "Spitting involved"
+                },
+                {
+                  "name": "N",
+                  "display": "Spitting not involved"
+                }
+              ]
+            }
+          },
+          {
+            "name": "$ref:cutting",
+            "display": "Cutting",
+            "sortable": false,
+            "visible": "false",
+            "filter": {
+              "type": "radio",
+              "staticoptions": [
+                {
+                  "name": "Y",
+                  "display": "Cutting involved"
+                },
+                {
+                  "name": "N",
+                  "display": "Cutting not involved"
+                }
+              ]
+            }
+          },
+          {
+            "name": "$ref:strangulation_or_hanging",
+            "display": "Strangulation or hanging",
+            "sortable": false,
+            "visible": "false",
+            "filter": {
+              "type": "radio",
+              "staticoptions": [
+                {
+                  "name": "Y",
+                  "display": "Strangulation or hanging involved"
+                },
+                {
+                  "name": "N",
+                  "display": "No strangulation or hanging involved"
+                }
+              ]
+            }
+          },
+          {
+            "name": "$ref:burning",
+            "display": "Burning",
+            "sortable": false,
+            "visible": "false",
+            "filter": {
+              "type": "radio",
+              "staticoptions": [
+                {
+                  "name": "Y",
+                  "display": "Burning involved"
+                },
+                {
+                  "name": "N",
+                  "display": "No burning involved"
+                }
+              ]
+            }
+          },
+          {
+            "name": "$ref:finds_detail",
+            "display": "Finds detail",
+            "sortable": false,
+            "visible": "true",
+            "defaultsort": false
           }
         ]
       },

--- a/dpd/preprod/definitions/prisons/orphanage/incident-report.json
+++ b/dpd/preprod/definitions/prisons/orphanage/incident-report.json
@@ -8,13 +8,14 @@
     "version": "1.0.0",
     "owner": "Managing Safety",
     "tags": [
-      "DPS", "Incident Reporting"
+      "DPS",
+      "Incident Reporting"
     ]
   },
   "datasource": [
     {
-      "id" : "datamart",
-      "name" : "datamart"
+      "id": "datamart",
+      "name": "datamart"
     }
   ],
   "policy": [
@@ -802,6 +803,161 @@
           },
           {
             "name": "other_method",
+            "type": "string"
+          }
+        ]
+      }
+    },
+    {
+      "id": "prisoner-incident-detail",
+      "name": "Prisoner Involvement in Incidents: Establishment Level",
+      "datasource": "datamart",
+      "query": "WITH qa_pivoted AS (\n    -- We scan the Q&A tables once and pivot all required answers into a single row per report\n    SELECT\n        q.report_id,\n\n        -- Assault Subtypes\n        MAX(CASE WHEN q.code IN ('61287', '44367') THEN\n                     CASE res.code\n                         WHEN '213115' THEN 'Prisoner on prisoner (PoP)'\n                         WHEN '213116' THEN 'Prisoner on staff (PoS)'\n                         WHEN '213117' THEN 'Prisoner on other'\n                         WHEN '213118' THEN 'Other'\n                         WHEN '179730' THEN 'Prisoner on prisoner (PoP)'\n                         WHEN '179732' THEN 'Prisoner on officer (PoS)'\n                         WHEN '179733' THEN 'Prisoner on other'\n                         WHEN '179731' THEN 'Other'\n                         END\n            END) AS assault_subtype,\n\n        -- Find Categories (Newer Versions)\n        MAX(CASE WHEN q.code IN ('67187', '65187') THEN\n                     CASE res.code\n                         WHEN '218783' THEN 'Multiple types'\n                         WHEN '218784' THEN 'Alcohol / hooch / distilling equipment'\n                         WHEN '218785' THEN 'Drug / drug equipment'\n                         WHEN '218786' THEN 'Mobile phone / mobile related item'\n                         WHEN '218787' THEN 'Digital find (excluding mobile phones)'\n                         WHEN '218788' THEN 'Tobacco / tobacco related items'\n                         WHEN '218789' THEN 'Weapon'\n                         WHEN '218790' THEN 'Other reportable items'\n                         WHEN '216784' THEN 'Multiple types'\n                         WHEN '216785' THEN 'Alcohol / hooch / distilling equipment'\n                         WHEN '216786' THEN 'Drug / drug equipment'\n                         WHEN '216787' THEN 'Mobile phone / mobile related item'\n                         WHEN '216788' THEN 'Digital find (excluding mobile phones)'\n                         WHEN '216789' THEN 'Tobacco / tobacco related items'\n                         WHEN '216790' THEN 'Weapon'\n                         WHEN '216791' THEN 'Other reportable items'\n                         END\n            END) AS find_category_new,\n\n        -- Legacy Find Logic Flags\n        MAX(CASE WHEN q.code IN ('49265','51234','51188','57288') AND res.code IN ('195011','198731','196731','209156') THEN 1 ELSE 0 END) AS found_drug,\n        MAX(CASE WHEN q.code IN ('49274','51242','51196','57296') AND res.code IN ('195045','198783','196783','209208') THEN 1 ELSE 0 END) AS found_mobile,\n        MAX(CASE WHEN q.code IN ('49289','51255','51209','57309') AND res.code IN ('195084','198874','196875','209297') THEN 1 ELSE 0 END) AS found_alcohol,\n\n        -- Flags for Assault Details\n        MAX(CASE WHEN (q.code = '61298' AND res.code = '213159') OR (q.code = '44773' AND res.code = '181164') THEN 'Y' END) AS is_serious,\n        MAX(CASE WHEN (q.code = '61305' AND res.code = '213197') OR (q.code = '44522' AND res.code = '180283') THEN 'Y' END) AS is_concussion,\n        MAX(CASE WHEN (q.code = '61285' AND res.code = '213111') OR (q.code = '44586' AND res.code = '180540') THEN 'Y' END) AS is_sexual,\n        MAX(CASE WHEN (q.code = '61300' AND res.code = '213173') OR (q.code = '44141' AND res.code = '178968') THEN 'Y' END) AS is_minor,\n        MAX(CASE WHEN (q.code = '61290' AND res.code = '213126') OR (q.code = '44464' AND res.code = '180077') THEN 'Y' END) AS is_spitting,\n\n        -- Flags for Self-Harm Details\n        MAX(CASE WHEN q.code = '44753' AND res.code = '181110' THEN 'Y' END) AS is_cutting,\n        MAX(CASE WHEN (q.code = '44244' AND res.code = '179302') OR (q.code = '44207' AND res.code = '179187') THEN 'Y' END) AS is_ligature,\n        MAX(CASE WHEN q.code = '45167' AND res.code = '182616' THEN 'Y' END) AS is_burning,\n\n        -- Text fields\n        MAX(CASE WHEN q.code = '61303' THEN\n                     CASE res.code\n                         WHEN '213182' THEN 'Accident and Emergency (A&E)'\n                         WHEN '213183' THEN 'Inpatient (overnight)'\n                         WHEN '213184' THEN 'Inpatient (over 24 hours)'\n                         WHEN '213185' THEN 'Life support'\n                         END\n            END) AS hospital_admission_type,\n        MAX(CASE WHEN (q.code = '61311' AND res.code = '213212') OR (q.code = '45074' AND res.code = '182269') THEN res.additional_information END) AS assault_reason,\n\n        -- FIND_6 Multiple types item detection (Q67205-67225 are exclusive to the Multiple flow)\n        MAX(CASE WHEN q.code = '67205' AND res.code != '218953' THEN 1 ELSE 0 END) AS f6m_alcohol,\n        MAX(CASE WHEN q.code = '67207' AND res.code = '218965' THEN 1 ELSE 0 END) AS f6m_drugs,\n        MAX(CASE WHEN q.code = '67213' AND res.code = '219014' THEN 1 ELSE 0 END) AS f6m_mobile,\n        MAX(CASE WHEN q.code = '67215' AND res.code != '219038' THEN 1 ELSE 0 END) AS f6m_sim,\n        MAX(CASE WHEN q.code = '67216' AND res.code != '219061' THEN 1 ELSE 0 END) AS f6m_memory,\n        MAX(CASE WHEN q.code = '67220' AND res.code != '219091' THEN 1 ELSE 0 END) AS f6m_digital,\n        MAX(CASE WHEN q.code = '67221' AND res.code = '219106' THEN 1 ELSE 0 END) AS f6m_tobacco,\n        MAX(CASE WHEN q.code = '67224' AND res.code != '219115' THEN 1 ELSE 0 END) AS f6m_weapon,\n        -- Incident location (where it took place) \u2014 covers active types + ASSAULT_1 legacy\n        MAX(CASE WHEN q.code IN ('61284', '45134', '45051', '67181', '63182', '49182', '44194', '100000', '44366', '44751', '44717', '45112', '45032', '44496', '44594', '44946', '45178', '45180', '44532', '44463', '44304', '44927') THEN\n            CASE res.code\n                -- ASSAULT_5 Q61284\n                WHEN '213074' THEN 'Administration'\n                WHEN '213075' THEN 'Association area' || COALESCE(' (' || NULLIF(res.additional_information, '') || ')', '')\n                WHEN '213076' THEN 'Cell' || COALESCE(' (' || NULLIF(res.additional_information, '') || ')', '')\n                WHEN '213077' THEN 'Chapel'\n                WHEN '213078' THEN 'Dining room'\n                WHEN '213079' THEN 'Dormitory'\n                WHEN '213080' THEN 'Education'\n                WHEN '213081' THEN 'Exercise yard'\n                WHEN '213082' THEN 'Gate'\n                WHEN '213083' THEN 'Gym'\n                WHEN '213084' THEN 'Health care centre'\n                WHEN '213085' THEN 'Kitchen'\n                WHEN '213086' THEN 'Office'\n                WHEN '213087' THEN 'Reception'\n                WHEN '213088' THEN 'Recess'\n                WHEN '213089' THEN 'Segregation unit'\n                WHEN '213090' THEN 'Special unit' || COALESCE(' (' || NULLIF(res.additional_information, '') || ')', '')\n                WHEN '213091' THEN 'Showers/changing room'\n                WHEN '213092' THEN 'Visits'\n                WHEN '213093' THEN 'Wing' || COALESCE(' (' || NULLIF(res.additional_information, '') || ')', '')\n                WHEN '213094' THEN 'Works department'\n                WHEN '213095' THEN 'Workshop' || COALESCE(' (' || NULLIF(res.additional_information, '') || ')', '')\n                WHEN '213096' THEN 'Within perimeter' || COALESCE(' (' || NULLIF(res.additional_information, '') || ')', '')\n                WHEN '213097' THEN 'Elsewhere' || COALESCE(' (' || NULLIF(res.additional_information, '') || ')', '')\n                WHEN '213098' THEN 'Funeral'\n                WHEN '213099' THEN 'Hospital outside (patient)'\n                WHEN '213100' THEN 'Hospital outside (visiting)'\n                WHEN '213101' THEN 'Outside working party' || COALESCE(' (' || NULLIF(res.additional_information, '') || ')', '')\n                WHEN '213102' THEN 'Sports field'\n                WHEN '213103' THEN 'Vehicle'\n                WHEN '213104' THEN 'Weddings'\n                WHEN '213105' THEN 'Magistrates court' || COALESCE(' (' || NULLIF(res.additional_information, '') || ')', '')\n                WHEN '213106' THEN 'Crown court' || COALESCE(' (' || NULLIF(res.additional_information, '') || ')', '')\n                WHEN '213107' THEN 'Induction/first night centre' || COALESCE(' (' || NULLIF(res.additional_information, '') || ')', '')\n                WHEN '213108' THEN 'Mail room'\n                WHEN '213109' THEN 'Vulnerable prisoners unit (VPU)' || COALESCE(' (' || NULLIF(res.additional_information, '') || ')', '')\n                WHEN '213110' THEN 'External roof' || COALESCE(' (' || NULLIF(res.additional_information, '') || ')', '')\n                -- ASSAULT_1 Q45134 (no comments on any response)\n                WHEN '182475' THEN 'Administration'\n                WHEN '182476' THEN 'Association area'\n                WHEN '182477' THEN 'Cell'\n                WHEN '182478' THEN 'Chapel'\n                WHEN '182479' THEN 'Crown court'\n                WHEN '182480' THEN 'Dining room'\n                WHEN '182481' THEN 'Dormitory'\n                WHEN '182482' THEN 'Education'\n                WHEN '182483' THEN 'Elsewhere'\n                WHEN '182484' THEN 'Exercise yard'\n                WHEN '182485' THEN 'Funeral'\n                WHEN '182486' THEN 'Gate'\n                WHEN '182487' THEN 'Gym'\n                WHEN '182488' THEN 'Health care centre'\n                WHEN '182489' THEN 'Hospital outside (patient)'\n                WHEN '182490' THEN 'Hospital outside (visiting)'\n                WHEN '182491' THEN 'Kitchen'\n                WHEN '182492' THEN 'Magistrates court'\n                WHEN '182493' THEN 'Office'\n                WHEN '182494' THEN 'Outside working party'\n                WHEN '182495' THEN 'Reception'\n                WHEN '182496' THEN 'Recess'\n                WHEN '182497' THEN 'Segregation unit'\n                WHEN '182498' THEN 'Showers/changing room'\n                WHEN '182499' THEN 'Special unit'\n                WHEN '182500' THEN 'Sports field'\n                WHEN '182501' THEN 'Vehicle'\n                WHEN '182502' THEN 'Visits'\n                WHEN '182503' THEN 'Weddings'\n                WHEN '182504' THEN 'Wing'\n                WHEN '182505' THEN 'Within perimeter'\n                WHEN '182506' THEN 'Works department'\n                WHEN '182507' THEN 'Workshop'\n                -- SELF_HARM_1 Q45051 (all have mandatory comment)\n                WHEN '182175' THEN 'Court cell' || COALESCE(' (' || NULLIF(res.additional_information, '') || ')', '')\n                WHEN '182176' THEN 'Detox unit' || COALESCE(' (' || NULLIF(res.additional_information, '') || ')', '')\n                WHEN '182177' THEN 'Health care centre' || COALESCE(' (' || NULLIF(res.additional_information, '') || ')', '')\n                WHEN '182178' THEN 'Indct''n/recp''n/1st nightcentre' || COALESCE(' (' || NULLIF(res.additional_information, '') || ')', '')\n                WHEN '182179' THEN 'Ordinary' || COALESCE(' (' || NULLIF(res.additional_information, '') || ')', '')\n                WHEN '182180' THEN 'Other' || COALESCE(' (' || NULLIF(res.additional_information, '') || ')', '')\n                WHEN '182181' THEN 'Prison escort vehicle' || COALESCE(' (' || NULLIF(res.additional_information, '') || ')', '')\n                WHEN '182182' THEN 'Segregation unit' || COALESCE(' (' || NULLIF(res.additional_information, '') || ')', '')\n                WHEN '182183' THEN 'VPU/other protected' || COALESCE(' (' || NULLIF(res.additional_information, '') || ')', '')\n                -- FIND_6 Q67181\n                WHEN '218712' THEN 'Administration'\n                WHEN '218713' THEN 'Association area' || COALESCE(' (' || NULLIF(res.additional_information, '') || ')', '')\n                WHEN '218714' THEN 'Cell' || COALESCE(' (' || NULLIF(res.additional_information, '') || ')', '')\n                WHEN '218715' THEN 'Chapel'\n                WHEN '218716' THEN 'Court'\n                WHEN '218717' THEN 'Dining room' || COALESCE(' (' || NULLIF(res.additional_information, '') || ')', '')\n                WHEN '218718' THEN 'Dormitory' || COALESCE(' (' || NULLIF(res.additional_information, '') || ')', '')\n                WHEN '218719' THEN 'Education'\n                WHEN '218720' THEN 'Exercise yard' || COALESCE(' (' || NULLIF(res.additional_information, '') || ')', '')\n                WHEN '218721' THEN 'Gate/gate lodge'\n                WHEN '218722' THEN 'Gym'\n                WHEN '218723' THEN 'Health care centre'\n                WHEN '218724' THEN 'Hospital outside (patient)'\n                WHEN '218725' THEN 'Hospital outside (visiting)'\n                WHEN '218726' THEN 'Induction/first night centre'\n                WHEN '218727' THEN 'Kitchen'\n                WHEN '218728' THEN 'Mail room'\n                WHEN '218729' THEN 'Office'\n                WHEN '218730' THEN 'Outside working party'\n                WHEN '218731' THEN 'Reception'\n                WHEN '218732' THEN 'Recess/ roof void'\n                WHEN '218733' THEN 'Segregation unit' || COALESCE(' (' || NULLIF(res.additional_information, '') || ')', '')\n                WHEN '218734' THEN 'Showers/changing room' || COALESCE(' (' || NULLIF(res.additional_information, '') || ')', '')\n                WHEN '218735' THEN 'Vehicle used for court/transfer'\n                WHEN '218736' THEN 'Visits'\n                WHEN '218737' THEN 'Vulnerable prisoners unit (VPU)' || COALESCE(' (' || NULLIF(res.additional_information, '') || ')', '')\n                WHEN '218738' THEN 'Wing' || COALESCE(' (' || NULLIF(res.additional_information, '') || ')', '')\n                WHEN '218739' THEN 'Workshop' || COALESCE(' (' || NULLIF(res.additional_information, '') || ')', '')\n                WHEN '218740' THEN 'Other' || COALESCE(' (' || NULLIF(res.additional_information, '') || ')', '')\n                -- DISORDER_2 Q63182 (all no comment except 214729)\n                WHEN '214694' THEN 'Administration'\n                WHEN '214695' THEN 'Association area'\n                WHEN '214696' THEN 'Cell'\n                WHEN '214697' THEN 'Chapel'\n                WHEN '214698' THEN 'Crown court'\n                WHEN '214699' THEN 'Dining room'\n                WHEN '214700' THEN 'Dormitory'\n                WHEN '214701' THEN 'Education'\n                WHEN '214702' THEN 'Exercise yard'\n                WHEN '214703' THEN 'External roof'\n                WHEN '214704' THEN 'Funeral'\n                WHEN '214705' THEN 'Gate'\n                WHEN '214706' THEN 'Gym'\n                WHEN '214707' THEN 'Health care centre'\n                WHEN '214708' THEN 'Hospital outside (patient)'\n                WHEN '214709' THEN 'Hospital outside (visiting)'\n                WHEN '214710' THEN 'Induction/1st night centre'\n                WHEN '214711' THEN 'Kitchen'\n                WHEN '214712' THEN 'Magistrates court'\n                WHEN '214713' THEN 'Office'\n                WHEN '214714' THEN 'Outside working party'\n                WHEN '214715' THEN 'Reception'\n                WHEN '214716' THEN 'Recess'\n                WHEN '214717' THEN 'Segregation unit'\n                WHEN '214718' THEN 'Showers/changing room'\n                WHEN '214719' THEN 'Special unit'\n                WHEN '214720' THEN 'Sports field'\n                WHEN '214721' THEN 'Vehicle'\n                WHEN '214722' THEN 'Visits'\n                WHEN '214723' THEN 'Vulnerable prisoners unit'\n                WHEN '214724' THEN 'Weddings'\n                WHEN '214725' THEN 'Wing'\n                WHEN '214726' THEN 'Within perimeter'\n                WHEN '214727' THEN 'Works department'\n                WHEN '214728' THEN 'Workshop'\n                WHEN '214729' THEN 'Other' || COALESCE(' (' || NULLIF(res.additional_information, '') || ')', '')\n                -- DISORDER_1 Q49182 (inactive, no comment except 194703)\n                WHEN '194695' THEN 'Administration'\n                WHEN '194696' THEN 'Association area'\n                WHEN '194697' THEN 'Cell'\n                WHEN '194698' THEN 'Chapel'\n                WHEN '194699' THEN 'Crown court'\n                WHEN '194700' THEN 'Dining room'\n                WHEN '194701' THEN 'Dormitory'\n                WHEN '194702' THEN 'Education'\n                WHEN '194703' THEN 'Elsewhere' || COALESCE(' (' || NULLIF(res.additional_information, '') || ')', '')\n                WHEN '194704' THEN 'Exercise yard'\n                WHEN '194705' THEN 'Funeral'\n                WHEN '194706' THEN 'Gate'\n                WHEN '194707' THEN 'Gym'\n                WHEN '194708' THEN 'Health care centre'\n                WHEN '194709' THEN 'Hospital outside (patient)'\n                WHEN '194710' THEN 'Hospital outside (visiting)'\n                WHEN '194711' THEN 'Kitchen'\n                WHEN '194712' THEN 'Magistrates court'\n                WHEN '194713' THEN 'Office'\n                WHEN '194714' THEN 'Outside working party'\n                WHEN '194715' THEN 'Reception'\n                WHEN '194716' THEN 'Recess'\n                WHEN '194717' THEN 'Segregation unit'\n                WHEN '194718' THEN 'Showers/changing room'\n                WHEN '194719' THEN 'Special unit'\n                WHEN '194720' THEN 'Sports field'\n                WHEN '194721' THEN 'Vehicle'\n                WHEN '194722' THEN 'Visits'\n                WHEN '194723' THEN 'Weddings'\n                WHEN '194724' THEN 'Wing'\n                WHEN '194725' THEN 'Within perimeter'\n                WHEN '194726' THEN 'Works department'\n                WHEN '194727' THEN 'Workshop'\n                WHEN '194728' THEN 'Induction/1st night centre'\n                WHEN '194729' THEN 'External roof'\n                WHEN '194730' THEN 'Vulnerable prisoners unit'\n                -- FIRE_1 Q44194\n                WHEN '179121' THEN 'Administration'\n                WHEN '179122' THEN 'Association area'\n                WHEN '179123' THEN 'Cell' || COALESCE(' (' || NULLIF(res.additional_information, '') || ')', '')\n                WHEN '179124' THEN 'Chapel'\n                WHEN '179126' THEN 'Dining room'\n                WHEN '179127' THEN 'Dormitory'\n                WHEN '179128' THEN 'Education'\n                WHEN '179130' THEN 'Exercise yard'\n                WHEN '179132' THEN 'Gate'\n                WHEN '179133' THEN 'Gym'\n                WHEN '179134' THEN 'Health care centre'\n                WHEN '179137' THEN 'Kitchen'\n                WHEN '179139' THEN 'Office'\n                WHEN '179141' THEN 'Reception'\n                WHEN '179142' THEN 'Recess'\n                WHEN '179143' THEN 'Segregation unit'\n                WHEN '179145' THEN 'Special unit'\n                WHEN '179144' THEN 'Showers/changing room'\n                WHEN '179148' THEN 'Visits'\n                WHEN '179150' THEN 'Wing'\n                WHEN '179152' THEN 'Works department'\n                WHEN '179153' THEN 'Workshop'\n                WHEN '179151' THEN 'Within perimeter'\n                WHEN '179129' THEN 'Elsewhere' || COALESCE(' (' || NULLIF(res.additional_information, '') || ')', '')\n                -- DIRTY_PROTEST_1 Q100000\n                WHEN '100001' THEN 'Ordinary cell' || COALESCE(' (' || NULLIF(res.additional_information, '') || ')', '')\n                WHEN '100002' THEN 'Specialist cell/unit' || COALESCE(' (' || NULLIF(res.additional_information, '') || ')', '')\n                WHEN '100003' THEN 'Shower/changing room' || COALESCE(' (' || NULLIF(res.additional_information, '') || ')', '')\n                WHEN '100004' THEN 'Other location within prison' || COALESCE(' (' || NULLIF(res.additional_information, '') || ')', '')\n                WHEN '100005' THEN 'Crown/magistrates court'\n                WHEN '100006' THEN 'Court cell'\n                WHEN '100007' THEN 'Vehicle' || COALESCE(' (' || NULLIF(res.additional_information, '') || ')', '')\n                -- DEATH_PRISONER_1 Q44366\n                WHEN '179724' THEN 'Single cell: ordinary location'\n                WHEN '179725' THEN 'Single cell: segregation unit'\n                WHEN '179723' THEN 'Shared cell: ordinary location'\n                WHEN '179727' THEN 'Special cell: segregation unit'\n                WHEN '179726' THEN 'Single cell: health care centre'\n                WHEN '179729' THEN 'Ward: health care centre'\n                WHEN '179728' THEN 'Unfurnished room: health care centre'\n                WHEN '179722' THEN 'Protective room: health care centre'\n                WHEN '179721' THEN 'Other' || COALESCE(' (' || NULLIF(res.additional_information, '') || ')', '')\n                -- DEATH_OTHER_1 Q44751 (single freetext response)\n                WHEN '181107' THEN NULLIF(res.additional_information, '')\n                -- ABSCOND_1 Q44717\n                WHEN '180993' THEN 'From establishment'\n                WHEN '180995' THEN 'Supervised outside party'\n                WHEN '180996' THEN 'Unsupervised outside party'\n                WHEN '180994' THEN 'Other' || COALESCE(' (' || NULLIF(res.additional_information, '') || ')', '')\n                -- ESCAPE_FROM_ESCORT_1 Q45112\n                WHEN '182389' THEN 'Vehicle en route to venue'\n                WHEN '182388' THEN 'Vehicle en route from venue'\n                WHEN '182387' THEN 'Leaving vehicle (debussing)'\n                WHEN '182386' THEN 'Entering vehicle (embussing)'\n                WHEN '182398' THEN 'Unscheduled stop'\n                WHEN '182390' THEN 'Cell at court'\n                WHEN '182391' THEN 'Court cells area'\n                WHEN '182393' THEN 'Court visits area'\n                WHEN '182392' THEN 'Court dock'\n                WHEN '182396' THEN 'Hospital ward/room'\n                WHEN '182394' THEN 'Hospital treatment room'\n                WHEN '182395' THEN 'Hospital waiting area'\n                WHEN '182397' THEN 'Other' || COALESCE(' (' || NULLIF(res.additional_information, '') || ')', '')\n                -- ESCAPE_FROM_PRISON_1 Q45032\n                WHEN '182064' THEN 'Sports field'\n                WHEN '182065' THEN 'Cell' || COALESCE(' (' || NULLIF(res.additional_information, '') || ')', '')\n                WHEN '182066' THEN 'Visits'\n                WHEN '182079' THEN 'Wing/houseblock'\n                WHEN '182069' THEN 'Dormitory'\n                WHEN '182074' THEN 'Health care centre'\n                WHEN '182068' THEN 'Chapel'\n                WHEN '182075' THEN 'Kitchen'\n                WHEN '182070' THEN 'Education/library'\n                WHEN '182081' THEN 'Workshop'\n                WHEN '182078' THEN 'Stores'\n                WHEN '182067' THEN 'Administration'\n                WHEN '182073' THEN 'Gymnasium'\n                WHEN '182077' THEN 'Reception'\n                WHEN '182080' THEN 'Works department'\n                WHEN '182071' THEN 'Exercise yard'\n                WHEN '182076' THEN 'Other secure area' || COALESCE(' (' || NULLIF(res.additional_information, '') || ')', '')\n                WHEN '182072' THEN 'Grounds with no access to external perimeter'\n                WHEN '182082' THEN 'Grounds with access to external perimeter'\n                -- ATTEMPTED_ESCAPE_FROM_ESCORT_1 Q44496\n                WHEN '180197' THEN 'Vehicle en route to venue'\n                WHEN '180196' THEN 'Vehicle en route from venue'\n                WHEN '180195' THEN 'Leaving vehicle (debussing)'\n                WHEN '180194' THEN 'Entering vehicle (embussing)'\n                WHEN '180206' THEN 'Unscheduled stop'\n                WHEN '180198' THEN 'Cell at court'\n                WHEN '180199' THEN 'Court cells area'\n                WHEN '180201' THEN 'Court visits area'\n                WHEN '180200' THEN 'Court dock'\n                WHEN '180204' THEN 'Hospital ward/room'\n                WHEN '180202' THEN 'Hospital treatment room'\n                WHEN '180203' THEN 'Hospital waiting area'\n                WHEN '180205' THEN 'Other' || COALESCE(' (' || NULLIF(res.additional_information, '') || ')', '')\n                -- ATTEMPTED_ESCAPE_FROM_PRISON_1 Q44594\n                WHEN '180572' THEN 'Sports field'\n                WHEN '180573' THEN 'Cell' || COALESCE(' (' || NULLIF(res.additional_information, '') || ')', '')\n                WHEN '180574' THEN 'Visits'\n                WHEN '180588' THEN 'Wing/houseblock'\n                WHEN '180577' THEN 'Dormitory'\n                WHEN '180583' THEN 'Health care centre'\n                WHEN '180576' THEN 'Chapel'\n                WHEN '180584' THEN 'Kitchen'\n                WHEN '180578' THEN 'Education/library'\n                WHEN '180590' THEN 'Workshop'\n                WHEN '180587' THEN 'Stores'\n                WHEN '180575' THEN 'Administration'\n                WHEN '180582' THEN 'Gymnasium'\n                WHEN '180586' THEN 'Reception'\n                WHEN '180589' THEN 'Works department'\n                WHEN '180579' THEN 'Exercise yard'\n                WHEN '180585' THEN 'Other secure area' || COALESCE(' (' || NULLIF(res.additional_information, '') || ')', '')\n                WHEN '180581' THEN 'Grounds with no access to external perimeter'\n                WHEN '180580' THEN 'Grounds with access to external perimeter'\n                -- BREACH_OF_SECURITY_1 Q44946\n                WHEN '181777' THEN 'Inside prison' || COALESCE(' (' || NULLIF(res.additional_information, '') || ')', '')\n                WHEN '181778' THEN 'Outside prison'\n                -- BOMB_1 Q45178\n                WHEN '182651' THEN 'Administration'\n                WHEN '182652' THEN 'Association area'\n                WHEN '182653' THEN 'Cell'\n                WHEN '182654' THEN 'Chapel'\n                WHEN '182655' THEN 'Crown court'\n                WHEN '182656' THEN 'Dining room'\n                WHEN '182657' THEN 'Dormitory'\n                WHEN '182658' THEN 'Education'\n                WHEN '182659' THEN 'Elsewhere' || COALESCE(' (' || NULLIF(res.additional_information, '') || ')', '')\n                WHEN '182660' THEN 'Exercise yard'\n                WHEN '182661' THEN 'Funeral'\n                WHEN '182662' THEN 'Gate'\n                WHEN '182663' THEN 'Gym'\n                WHEN '182664' THEN 'Health care centre'\n                WHEN '182665' THEN 'Hospital outside (patient)'\n                WHEN '182666' THEN 'Hospital outside (visiting)'\n                WHEN '182667' THEN 'Kitchen'\n                WHEN '182668' THEN 'Magistrates court'\n                WHEN '182669' THEN 'Office'\n                WHEN '182670' THEN 'Outside working party'\n                WHEN '182671' THEN 'Reception'\n                WHEN '182672' THEN 'Recess'\n                WHEN '182673' THEN 'Segregation unit'\n                WHEN '182674' THEN 'Showers/changing room'\n                WHEN '182675' THEN 'Special unit'\n                WHEN '182676' THEN 'Sports field'\n                WHEN '182677' THEN 'Vehicle'\n                WHEN '182678' THEN 'Visits'\n                WHEN '182679' THEN 'Weddings'\n                WHEN '182680' THEN 'Wing'\n                WHEN '182681' THEN 'Within perimeter'\n                WHEN '182682' THEN 'Works department'\n                WHEN '182683' THEN 'Workshop'\n                -- RELEASE_IN_ERROR_1 Q45180 (multipleAnswers, all mandatory comment)\n                WHEN '183026' THEN 'Establishment' || COALESCE(' (' || NULLIF(res.additional_information, '') || ')', '')\n                WHEN '183027' THEN 'Court' || COALESCE(' (' || NULLIF(res.additional_information, '') || ')', '')\n                WHEN '183028' THEN 'Other' || COALESCE(' (' || NULLIF(res.additional_information, '') || ')', '')\n                -- BARRICADE_1 Q44532 (inactive type, legacy)\n                WHEN '180354' THEN 'Administration'\n                WHEN '180355' THEN 'Association area'\n                WHEN '180356' THEN 'Cell'\n                WHEN '180357' THEN 'Chapel'\n                WHEN '180358' THEN 'Crown court'\n                WHEN '180359' THEN 'Dining room'\n                WHEN '180360' THEN 'Dormitory'\n                WHEN '180361' THEN 'Education'\n                WHEN '180362' THEN 'Elsewhere' || COALESCE(' (' || NULLIF(res.additional_information, '') || ')', '')\n                WHEN '180363' THEN 'Exercise yard'\n                WHEN '180364' THEN 'Funeral'\n                WHEN '180365' THEN 'Gate'\n                WHEN '180366' THEN 'Gym'\n                WHEN '180367' THEN 'Health care centre'\n                WHEN '180368' THEN 'Hospital outside (patient)'\n                WHEN '180369' THEN 'Hospital outside (visiting)'\n                WHEN '180370' THEN 'Kitchen'\n                WHEN '180371' THEN 'Magistrates court'\n                WHEN '180372' THEN 'Office'\n                WHEN '180373' THEN 'Outside working party'\n                WHEN '180374' THEN 'Reception'\n                WHEN '180375' THEN 'Recess'\n                WHEN '180376' THEN 'Segregation unit'\n                WHEN '180377' THEN 'Showers/changing room'\n                WHEN '180378' THEN 'Special unit'\n                WHEN '180379' THEN 'Sports field'\n                WHEN '180380' THEN 'Vehicle'\n                WHEN '180381' THEN 'Visits'\n                WHEN '180382' THEN 'Weddings'\n                WHEN '180383' THEN 'Wing'\n                WHEN '180384' THEN 'Within perimeter'\n                WHEN '180385' THEN 'Works department'\n                WHEN '180386' THEN 'Workshop'\n                -- HOSTAGE_1 Q44463 (inactive type, legacy)\n                WHEN '180034' THEN 'Administration'\n                WHEN '180035' THEN 'Association area'\n                WHEN '180036' THEN 'Cell'\n                WHEN '180037' THEN 'Chapel'\n                WHEN '180038' THEN 'Crown court'\n                WHEN '180039' THEN 'Dining room'\n                WHEN '180040' THEN 'Dormitory'\n                WHEN '180041' THEN 'Education'\n                WHEN '180042' THEN 'Elsewhere' || COALESCE(' (' || NULLIF(res.additional_information, '') || ')', '')\n                WHEN '180043' THEN 'Exercise yard'\n                WHEN '180044' THEN 'Funeral'\n                WHEN '180045' THEN 'Gate'\n                WHEN '180046' THEN 'Gym'\n                WHEN '180047' THEN 'Health care centre'\n                WHEN '180048' THEN 'Hospital outside (patient)'\n                WHEN '180049' THEN 'Hospital outside (visiting)'\n                WHEN '180050' THEN 'Kitchen'\n                WHEN '180051' THEN 'Magistrates court'\n                WHEN '180052' THEN 'Office'\n                WHEN '180053' THEN 'Outside working party'\n                WHEN '180054' THEN 'Reception'\n                WHEN '180055' THEN 'Recess'\n                WHEN '180056' THEN 'Segregation unit'\n                WHEN '180057' THEN 'Showers/changing room'\n                WHEN '180058' THEN 'Special unit'\n                WHEN '180059' THEN 'Sports field'\n                WHEN '180060' THEN 'Vehicle'\n                WHEN '180061' THEN 'Visits'\n                WHEN '180062' THEN 'Weddings'\n                WHEN '180063' THEN 'Wing'\n                WHEN '180064' THEN 'Within perimeter'\n                WHEN '180065' THEN 'Works department'\n                WHEN '180066' THEN 'Workshop'\n                -- CONCERTED_INDISCIPLINE_1 Q44304 (inactive type, legacy)\n                WHEN '179481' THEN 'Administration'\n                WHEN '179482' THEN 'Association area'\n                WHEN '179483' THEN 'Cell'\n                WHEN '179484' THEN 'Chapel'\n                WHEN '179485' THEN 'Crown court'\n                WHEN '179486' THEN 'Dining room'\n                WHEN '179487' THEN 'Dormitory'\n                WHEN '179488' THEN 'Education'\n                WHEN '179489' THEN 'Elsewhere' || COALESCE(' (' || NULLIF(res.additional_information, '') || ')', '')\n                WHEN '179490' THEN 'Exercise yard'\n                WHEN '179491' THEN 'Funeral'\n                WHEN '179492' THEN 'Gate'\n                WHEN '179493' THEN 'Gym'\n                WHEN '179494' THEN 'Health care centre'\n                WHEN '179495' THEN 'Hospital outside (patient)'\n                WHEN '179496' THEN 'Hospital outside (visiting)'\n                WHEN '179497' THEN 'Kitchen'\n                WHEN '179498' THEN 'Magistrates court'\n                WHEN '179499' THEN 'Office'\n                WHEN '179500' THEN 'Outside working party'\n                WHEN '179501' THEN 'Reception'\n                WHEN '179502' THEN 'Recess'\n                WHEN '179503' THEN 'Segregation unit'\n                WHEN '179504' THEN 'Showers/changing room'\n                WHEN '179505' THEN 'Special unit'\n                WHEN '179506' THEN 'Sports field'\n                WHEN '179507' THEN 'Vehicle'\n                WHEN '179508' THEN 'Visits'\n                WHEN '179509' THEN 'Weddings'\n                WHEN '179510' THEN 'Wing'\n                WHEN '179511' THEN 'Within perimeter'\n                WHEN '179512' THEN 'Works department'\n                WHEN '179513' THEN 'Workshop'\n                -- INCIDENT_AT_HEIGHT_1 Q44927 (inactive type, legacy)\n                WHEN '181684' THEN 'Administration'\n                WHEN '181685' THEN 'Association area'\n                WHEN '181686' THEN 'Cell'\n                WHEN '181687' THEN 'Chapel'\n                WHEN '181688' THEN 'Crown court'\n                WHEN '181689' THEN 'Dining room'\n                WHEN '181690' THEN 'Dormitory'\n                WHEN '181691' THEN 'Education'\n                WHEN '181692' THEN 'Elsewhere' || COALESCE(' (' || NULLIF(res.additional_information, '') || ')', '')\n                WHEN '181693' THEN 'Exercise yard'\n                WHEN '181694' THEN 'Funeral'\n                WHEN '181695' THEN 'Gate'\n                WHEN '181696' THEN 'Gym'\n                WHEN '181697' THEN 'Health care centre'\n                WHEN '181698' THEN 'Hospital outside (patient)'\n                WHEN '181699' THEN 'Hospital outside (visiting)'\n                WHEN '181700' THEN 'Kitchen'\n                WHEN '181701' THEN 'Magistrates court'\n                WHEN '181702' THEN 'Office'\n                WHEN '181703' THEN 'Outside working party'\n                WHEN '181704' THEN 'Reception'\n                WHEN '181705' THEN 'Recess'\n                WHEN '181706' THEN 'Segregation unit'\n                WHEN '181707' THEN 'Showers/changing room'\n                WHEN '181708' THEN 'Special unit'\n                WHEN '181709' THEN 'Sports field'\n                WHEN '181710' THEN 'Vehicle'\n                WHEN '181711' THEN 'Visits'\n                WHEN '181712' THEN 'Weddings'\n                WHEN '181713' THEN 'Wing'\n                WHEN '181714' THEN 'Within perimeter'\n                WHEN '181715' THEN 'Works department'\n                WHEN '181716' THEN 'Workshop'\n            END\n        END) AS incident_location\n\n    FROM prisons.incidentreporting_question q\n             JOIN prisons.incidentreporting_response res ON res.question_id = q.id\n    GROUP BY 1\n)\n\nSELECT\n    r.id,\n    r.report_reference,\n    r.location,\n    p.name AS location_name,\n    al.noms_region_code AS region_code,\n    area.description AS region_name,\n    ctf.code AS type,\n    ct.description AS type_description,\n\n    -- incident_subtype logic refactored\n    CASE\n        WHEN ctf.code = 'ASSAULT' THEN qa.assault_subtype\n        WHEN ctf.code = 'BARRICADE' THEN 'Barricade'\n        WHEN ctf.code = 'CONCERTED_INDISCIPLINE' THEN 'Concerted Indiscipline'\n        WHEN ctf.code = 'HOSTAGE' THEN 'Hostage'\n        WHEN ctf.code = 'INCIDENT_AT_HEIGHT' THEN 'Incident at Height'\n        WHEN ctf.code = 'DISORDER' THEN 'Disorder'\n        WHEN ctf.code = 'FIND' THEN\n            COALESCE(qa.find_category_new,\n                     CASE\n                         WHEN (qa.found_drug + qa.found_mobile + qa.found_alcohol) > 1 THEN 'Multiple types'\n                         WHEN qa.found_drug = 1 THEN 'Drug / drug equipment'\n                         WHEN qa.found_mobile = 1 THEN 'Mobile phone / mobile related item'\n                         WHEN qa.found_alcohol = 1 THEN 'Alcohol / hooch / distilling equipment'\n                         END\n            )\n        END AS incident_subtype,\n\n    r.status,\n    cs.description AS status_description,\n    r.incident_date_and_time,\n    r.reported_by,\n    INITCAP(pi.first_name) AS first_name,\n    INITCAP(pi.last_name) AS last_name,\n    pi.prisoner_number,\n    cpr.description AS prisoner_role,\n    pi.comment AS prisoner_comment,\n\n    -- Assault Extra Info\n    CASE WHEN ctf.code = 'ASSAULT' THEN COALESCE(qa.is_serious, 'N') END AS serious_injury,\n    CASE WHEN ctf.code = 'ASSAULT' THEN COALESCE(qa.is_concussion, 'N') END AS concussion_treatment,\n    qa.hospital_admission_type,\n    CASE WHEN ctf.code = 'ASSAULT' THEN COALESCE(qa.is_sexual, 'N') END AS sexual_assault,\n    CASE WHEN ctf.code = 'ASSAULT' THEN COALESCE(qa.is_minor, 'N') END AS minor_assault,\n    CASE WHEN ctf.code = 'ASSAULT' THEN COALESCE(qa.is_spitting, 'N') END AS spitting,\n    qa.assault_reason,\n\n    -- Self-Harm Extra Info\n    CASE WHEN ctf.code = 'SELF_HARM' THEN COALESCE(qa.is_cutting, 'N') END AS cutting,\n    CASE WHEN ctf.code = 'SELF_HARM' THEN COALESCE(qa.is_ligature, 'N') END AS strangulation_or_hanging,\n    CASE WHEN ctf.code = 'SELF_HARM' THEN COALESCE(qa.is_burning, 'N') END AS burning,\n\n    -- Finds Extra Info\n    CASE WHEN ctf.code = 'FIND' THEN\n        NULLIF(REGEXP_REPLACE(\n            CASE WHEN COALESCE(qa.f6m_alcohol, 0) = 1 OR COALESCE(qa.found_alcohol, 0) = 1 THEN 'Alcohol, ' ELSE '' END ||\n            CASE WHEN COALESCE(qa.f6m_drugs, 0) = 1 OR COALESCE(qa.found_drug, 0) = 1 THEN 'Drugs, ' ELSE '' END ||\n            CASE WHEN COALESCE(qa.f6m_mobile, 0) = 1 OR COALESCE(qa.found_mobile, 0) = 1 THEN 'Mobile phone, ' ELSE '' END ||\n            CASE WHEN COALESCE(qa.f6m_sim, 0) = 1 THEN 'SIM card, ' ELSE '' END ||\n            CASE WHEN COALESCE(qa.f6m_memory, 0) = 1 THEN 'Memory card, ' ELSE '' END ||\n            CASE WHEN COALESCE(qa.f6m_digital, 0) = 1 THEN 'Digital, ' ELSE '' END ||\n            CASE WHEN COALESCE(qa.f6m_tobacco, 0) = 1 THEN 'Tobacco, ' ELSE '' END ||\n            CASE WHEN COALESCE(qa.f6m_weapon, 0) = 1 THEN 'Weapon, ' ELSE '' END\n        , ',\\\\s*$', ''), '')\n    END AS finds_detail,\n\n    qa.incident_location,\n    -- Incident summary: key facts for the incident type in plain words\n    CASE\n        WHEN ctf.code = 'ASSAULT' THEN\n            NULLIF(REGEXP_REPLACE(\n                CASE WHEN COALESCE(qa.is_serious, 'N') = 'Y' THEN 'Serious injury, ' ELSE '' END ||\n                CASE WHEN COALESCE(qa.is_sexual, 'N') = 'Y' THEN 'Sexual assault, ' ELSE '' END ||\n                CASE WHEN COALESCE(qa.is_minor, 'N') = 'Y' THEN 'Minor assault, ' ELSE '' END ||\n                CASE WHEN COALESCE(qa.is_spitting, 'N') = 'Y' THEN 'Spitting, ' ELSE '' END ||\n                CASE WHEN COALESCE(qa.is_concussion, 'N') = 'Y' THEN 'Concussion treatment, ' ELSE '' END ||\n                CASE WHEN qa.hospital_admission_type IS NOT NULL THEN qa.hospital_admission_type || ', ' ELSE '' END\n            , ',\\\\s*$', ''), '')\n        WHEN ctf.code = 'SELF_HARM' THEN\n            NULLIF(REGEXP_REPLACE(\n                CASE WHEN COALESCE(qa.is_cutting, 'N') = 'Y' THEN 'Cutting, ' ELSE '' END ||\n                CASE WHEN COALESCE(qa.is_ligature, 'N') = 'Y' THEN 'Strangulation or hanging, ' ELSE '' END ||\n                CASE WHEN COALESCE(qa.is_burning, 'N') = 'Y' THEN 'Burning, ' ELSE '' END\n            , ',\\\\s*$', ''), '')\n        WHEN ctf.code = 'FIND' THEN\n            NULLIF(REGEXP_REPLACE(\n                CASE WHEN COALESCE(qa.f6m_alcohol, 0) = 1 OR COALESCE(qa.found_alcohol, 0) = 1 THEN 'Alcohol, ' ELSE '' END ||\n                CASE WHEN COALESCE(qa.f6m_drugs, 0) = 1 OR COALESCE(qa.found_drug, 0) = 1 THEN 'Drugs, ' ELSE '' END ||\n                CASE WHEN COALESCE(qa.f6m_mobile, 0) = 1 OR COALESCE(qa.found_mobile, 0) = 1 THEN 'Mobile phone, ' ELSE '' END ||\n                CASE WHEN COALESCE(qa.f6m_sim, 0) = 1 THEN 'SIM card, ' ELSE '' END ||\n                CASE WHEN COALESCE(qa.f6m_memory, 0) = 1 THEN 'Memory card, ' ELSE '' END ||\n                CASE WHEN COALESCE(qa.f6m_digital, 0) = 1 THEN 'Digital, ' ELSE '' END ||\n                CASE WHEN COALESCE(qa.f6m_tobacco, 0) = 1 THEN 'Tobacco, ' ELSE '' END ||\n                CASE WHEN COALESCE(qa.f6m_weapon, 0) = 1 THEN 'Weapon, ' ELSE '' END\n            , ',\\\\s*$', ''), '')\n    END AS incident_summary\n\nFROM prisons.incidentreporting_prisoner_involvement pi\n         JOIN prisons.incidentreporting_report r ON r.id = pi.report_id\n         JOIN prisons.incidentreporting_constant_status cs ON r.status = cs.code\n         JOIN prisons.incidentreporting_constant_type ct ON r.type = ct.code\n         JOIN prisons.incidentreporting_constant_type_family ctf ON ctf.code = ct.family_code\n         JOIN prisons.incidentreporting_constant_prisoner_role cpr ON cpr.code = pi.prisoner_role\n         JOIN prisons.prisonregister_prison p ON p.prison_id = r.location\n         JOIN prisons.nomis_agency_locations al ON al.agy_loc_id = p.prison_id\n         LEFT JOIN prisons.nomis_areas area ON area.area_class = 'REGION' AND area.area_code = al.noms_region_code\n         LEFT JOIN qa_pivoted qa ON qa.report_id = r.id\n\nWHERE r.status NOT IN ('DUPLICATE', 'NOT_REPORTABLE', 'DRAFT')",
+      "schema": {
+        "field": [
+          {
+            "name": "id",
+            "type": "string"
+          },
+          {
+            "name": "report_reference",
+            "type": "string"
+          },
+          {
+            "name": "type",
+            "type": "string",
+            "filter": {
+              "type": "multiselect",
+              "dynamicoptions": {
+                "maximumOptions": 60,
+                "returnAsStaticOptions": true,
+                "dataset": "types",
+                "name": "code",
+                "display": "description"
+              }
+            }
+          },
+          {
+            "name": "type_description",
+            "type": "string"
+          },
+          {
+            "name": "status",
+            "type": "string",
+            "filter": {
+              "type": "multiselect",
+              "interactive": true,
+              "dynamicoptions": {
+                "maximumOptions": 20,
+                "returnAsStaticOptions": true,
+                "dataset": "status",
+                "name": "code",
+                "display": "description"
+              }
+            }
+          },
+          {
+            "name": "status_description",
+            "type": "string"
+          },
+          {
+            "name": "incident_date_and_time",
+            "type": "datetime"
+          },
+          {
+            "name": "reported_by",
+            "type": "string"
+          },
+          {
+            "name": "first_name",
+            "type": "string"
+          },
+          {
+            "name": "last_name",
+            "type": "string"
+          },
+          {
+            "name": "prisoner_number",
+            "type": "string"
+          },
+          {
+            "name": "prisoner_role",
+            "type": "string"
+          },
+          {
+            "name": "prisoner_comment",
+            "type": "string"
+          },
+          {
+            "name": "location",
+            "type": "string"
+          },
+          {
+            "name": "location_name",
+            "type": "string"
+          },
+          {
+            "name": "region_code",
+            "type": "string"
+          },
+          {
+            "name": "region_name",
+            "type": "string"
+          },
+          {
+            "name": "incident_subtype",
+            "type": "string"
+          },
+          {
+            "name": "serious_injury",
+            "type": "string"
+          },
+          {
+            "name": "concussion_treatment",
+            "type": "string"
+          },
+          {
+            "name": "hospital_admission_type",
+            "type": "string"
+          },
+          {
+            "name": "sexual_assault",
+            "type": "string"
+          },
+          {
+            "name": "minor_assault",
+            "type": "string"
+          },
+          {
+            "name": "spitting",
+            "type": "string"
+          },
+          {
+            "name": "assault_reason",
+            "type": "string"
+          },
+          {
+            "name": "cutting",
+            "type": "string"
+          },
+          {
+            "name": "strangulation_or_hanging",
+            "type": "string"
+          },
+          {
+            "name": "burning",
+            "type": "string"
+          },
+          {
+            "name": "finds_detail",
+            "type": "string"
+          },
+          {
+            "name": "incident_location",
+            "type": "string"
+          },
+          {
+            "name": "incident_summary",
             "type": "string"
           }
         ]
@@ -2128,6 +2284,387 @@
             "defaultsort": true,
             "sortdirection": "desc",
             "formula": "make_url('https://incident-reporting-${env}.hmpps.service.justice.gov.uk/reports?searchID=${prisoner_number}',${total_incidents},TRUE)"
+          }
+        ]
+      },
+      "destination": []
+    },
+    {
+      "id": "prisoner-incident-detail",
+      "name": "Prisoner Involvement in Incidents: Establishment Level",
+      "description": "Shows each prisoner involved in a reported incident alongside their role, any comments recorded against them, and the where the incident took place. For key incident types, structured Q&A detail is surfaced as additional columns: assault severity flags (serious, sexual, minor, spitting, concussion treatment, hospital admission, and reason); self-harm method flags (cutting, strangulation/hanging, burning); and for finds, a comma-separated list of items identified.",
+      "version": "1.0.0",
+      "dataset": "$ref:prisoner-incident-detail",
+      "render": "HTML",
+      "feature": [
+        {
+          "type": "print"
+        }
+      ],
+      "metadata": {
+        "hints": [
+          "interactive"
+        ]
+      },
+      "specification": {
+        "template": "list",
+        "field": [
+          {
+            "name": "$ref:prisoner_number",
+            "display": "Prisoner number",
+            "sortable": true,
+            "formula": "make_url('https://prisoner-${env}.digital.prison.service.justice.gov.uk/prisoner/${prisoner_number}',${prisoner_number},TRUE)",
+            "visible": "true",
+            "defaultsort": false,
+            "filter": {
+              "type": "text"
+            }
+          },
+          {
+            "name": "$ref:last_name",
+            "formula": "${last_name}, ${first_name}",
+            "display": "Name",
+            "sortable": true,
+            "visible": "true",
+            "defaultsort": false
+          },
+          {
+            "name": "$ref:report_reference",
+            "display": "Incident number",
+            "sortable": true,
+            "formula": "make_url('https://incident-reporting-${env}.hmpps.service.justice.gov.uk/reports/${id}',${report_reference},TRUE)",
+            "visible": "true",
+            "defaultsort": false
+          },
+          {
+            "name": "$ref:incident_date_and_time",
+            "display": "Date of incident",
+            "formula": "format_date(${incident_date_and_time}, 'dd/MM/yyyy HH:mm')",
+            "sortable": true,
+            "visible": "true",
+            "defaultsort": true,
+            "sortdirection": "desc",
+            "filter": {
+              "type": "daterange",
+              "default": "today(-1,months) - today()"
+            }
+          },
+          {
+            "name": "$ref:type",
+            "display": "Type code",
+            "sortable": true,
+            "visible": "false",
+            "defaultsort": false
+          },
+          {
+            "name": "$ref:type_description",
+            "display": "Incident type",
+            "sortable": true,
+            "visible": "true",
+            "defaultsort": false
+          },
+          {
+            "name": "$ref:status",
+            "display": "Status code",
+            "sortable": false,
+            "visible": "false",
+            "defaultsort": false
+          },
+          {
+            "name": "$ref:status_description",
+            "display": "Incident status",
+            "sortable": true,
+            "visible": "true",
+            "defaultsort": false
+          },
+          {
+            "name": "$ref:location",
+            "display": "Location",
+            "sortable": true,
+            "visible": "false",
+            "defaultsort": false,
+            "filter": {
+              "type": "multiselect",
+              "mandatory": false,
+              "dynamicoptions": {
+                "maximumOptions": 140,
+                "returnAsStaticOptions": true,
+                "dataset": "prisons",
+                "name": "prison_id",
+                "display": "prison_name"
+              }
+            }
+          },
+          {
+            "name": "$ref:location_name",
+            "display": "Location name",
+            "sortable": true,
+            "visible": "true",
+            "defaultsort": false
+          },
+          {
+            "name": "$ref:incident_subtype",
+            "display": "Subtype",
+            "sortable": true,
+            "visible": "true",
+            "defaultsort": false,
+            "filter": {
+              "type": "multiselect",
+              "mandatory": false,
+              "staticoptions": [
+                {
+                  "name": "Prisoner on prisoner (PoP)",
+                  "display": "Prisoner on prisoner (PoP)"
+                },
+                {
+                  "name": "Prisoner on staff (PoS)",
+                  "display": "Prisoner on staff (PoS)"
+                },
+                {
+                  "name": "Prisoner on other",
+                  "display": "Prisoner on other"
+                },
+                {
+                  "name": "Other",
+                  "display": "Other"
+                }
+              ]
+            }
+          },
+          {
+            "name": "$ref:region_code",
+            "display": "Region",
+            "sortable": true,
+            "visible": "false",
+            "defaultsort": false,
+            "filter": {
+              "type": "multiselect",
+              "mandatory": false,
+              "dynamicoptions": {
+                "maximumOptions": 20,
+                "returnAsStaticOptions": true,
+                "dataset": "regionCodes",
+                "name": "code",
+                "display": "description"
+              }
+            }
+          },
+          {
+            "name": "$ref:region_name",
+            "display": "Region name",
+            "sortable": true,
+            "visible": "false",
+            "defaultsort": false
+          },
+          {
+            "name": "$ref:prisoner_role",
+            "display": "Prisoner role",
+            "sortable": false,
+            "visible": "true",
+            "defaultsort": false,
+            "filter": {
+              "type": "multiselect",
+              "mandatory": false,
+              "dynamicoptions": {
+                "maximumOptions": 20,
+                "returnAsStaticOptions": true,
+                "dataset": "prisoner_role",
+                "name": "description",
+                "display": "description"
+              }
+            }
+          },
+          {
+            "name": "$ref:incident_location",
+            "display": "Incident location",
+            "sortable": false,
+            "visible": "true",
+            "defaultsort": false
+          },
+          {
+            "name": "$ref:incident_summary",
+            "display": "Incident summary",
+            "sortable": false,
+            "visible": "true",
+            "defaultsort": false
+          },
+          {
+            "name": "$ref:prisoner_comment",
+            "display": "Prisoner comment",
+            "sortable": false,
+            "visible": "true",
+            "defaultsort": false
+          },
+          {
+            "name": "$ref:assault_reason",
+            "display": "Assault reason",
+            "sortable": false,
+            "visible": "true"
+          },
+          {
+            "name": "$ref:serious_injury",
+            "display": "Serious injury",
+            "sortable": false,
+            "visible": "false",
+            "filter": {
+              "type": "radio",
+              "staticoptions": [
+                {
+                  "name": "Y",
+                  "display": "Serious injury"
+                },
+                {
+                  "name": "N",
+                  "display": "Non serious injury"
+                }
+              ]
+            }
+          },
+          {
+            "name": "$ref:concussion_treatment",
+            "display": "Concussion treatment",
+            "sortable": false,
+            "visible": "false",
+            "filter": {
+              "type": "radio",
+              "staticoptions": [
+                {
+                  "name": "Y",
+                  "display": "Concussion"
+                },
+                {
+                  "name": "N",
+                  "display": "No concussion"
+                }
+              ]
+            }
+          },
+          {
+            "name": "$ref:hospital_admission_type",
+            "display": "Hospital admission type",
+            "sortable": false,
+            "visible": "true"
+          },
+          {
+            "name": "$ref:sexual_assault",
+            "display": "Sexual assault",
+            "sortable": false,
+            "visible": "false",
+            "filter": {
+              "type": "radio",
+              "staticoptions": [
+                {
+                  "name": "Y",
+                  "display": "Sexual assault"
+                },
+                {
+                  "name": "N",
+                  "display": "Non-sexual assault"
+                }
+              ]
+            }
+          },
+          {
+            "name": "$ref:minor_assault",
+            "display": "Minor assault",
+            "sortable": false,
+            "visible": "false",
+            "filter": {
+              "type": "radio",
+              "staticoptions": [
+                {
+                  "name": "Y",
+                  "display": "Minor assault"
+                },
+                {
+                  "name": "N",
+                  "display": "Not a minor assault"
+                }
+              ]
+            }
+          },
+          {
+            "name": "$ref:spitting",
+            "display": "Spitting",
+            "sortable": false,
+            "visible": "false",
+            "filter": {
+              "type": "radio",
+              "staticoptions": [
+                {
+                  "name": "Y",
+                  "display": "Spitting involved"
+                },
+                {
+                  "name": "N",
+                  "display": "Spitting not involved"
+                }
+              ]
+            }
+          },
+          {
+            "name": "$ref:cutting",
+            "display": "Cutting",
+            "sortable": false,
+            "visible": "false",
+            "filter": {
+              "type": "radio",
+              "staticoptions": [
+                {
+                  "name": "Y",
+                  "display": "Cutting involved"
+                },
+                {
+                  "name": "N",
+                  "display": "Cutting not involved"
+                }
+              ]
+            }
+          },
+          {
+            "name": "$ref:strangulation_or_hanging",
+            "display": "Strangulation or hanging",
+            "sortable": false,
+            "visible": "false",
+            "filter": {
+              "type": "radio",
+              "staticoptions": [
+                {
+                  "name": "Y",
+                  "display": "Strangulation or hanging involved"
+                },
+                {
+                  "name": "N",
+                  "display": "No strangulation or hanging involved"
+                }
+              ]
+            }
+          },
+          {
+            "name": "$ref:burning",
+            "display": "Burning",
+            "sortable": false,
+            "visible": "false",
+            "filter": {
+              "type": "radio",
+              "staticoptions": [
+                {
+                  "name": "Y",
+                  "display": "Burning involved"
+                },
+                {
+                  "name": "N",
+                  "display": "No burning involved"
+                }
+              ]
+            }
+          },
+          {
+            "name": "$ref:finds_detail",
+            "display": "Finds detail",
+            "sortable": false,
+            "visible": "true",
+            "defaultsort": false
           }
         ]
       },

--- a/dpd/prod/definitions/prisons/orphanage/incident-report.json
+++ b/dpd/prod/definitions/prisons/orphanage/incident-report.json
@@ -8,13 +8,14 @@
     "version": "1.0.0",
     "owner": "Managing Safety",
     "tags": [
-      "DPS", "Incident Reporting"
+      "DPS",
+      "Incident Reporting"
     ]
   },
   "datasource": [
     {
-      "id" : "datamart",
-      "name" : "datamart"
+      "id": "datamart",
+      "name": "datamart"
     }
   ],
   "policy": [
@@ -802,6 +803,161 @@
           },
           {
             "name": "other_method",
+            "type": "string"
+          }
+        ]
+      }
+    },
+    {
+      "id": "prisoner-incident-detail",
+      "name": "Prisoner Involvement in Incidents: Establishment Level",
+      "datasource": "datamart",
+      "query": "WITH qa_pivoted AS (\n    -- We scan the Q&A tables once and pivot all required answers into a single row per report\n    SELECT\n        q.report_id,\n\n        -- Assault Subtypes\n        MAX(CASE WHEN q.code IN ('61287', '44367') THEN\n                     CASE res.code\n                         WHEN '213115' THEN 'Prisoner on prisoner (PoP)'\n                         WHEN '213116' THEN 'Prisoner on staff (PoS)'\n                         WHEN '213117' THEN 'Prisoner on other'\n                         WHEN '213118' THEN 'Other'\n                         WHEN '179730' THEN 'Prisoner on prisoner (PoP)'\n                         WHEN '179732' THEN 'Prisoner on officer (PoS)'\n                         WHEN '179733' THEN 'Prisoner on other'\n                         WHEN '179731' THEN 'Other'\n                         END\n            END) AS assault_subtype,\n\n        -- Find Categories (Newer Versions)\n        MAX(CASE WHEN q.code IN ('67187', '65187') THEN\n                     CASE res.code\n                         WHEN '218783' THEN 'Multiple types'\n                         WHEN '218784' THEN 'Alcohol / hooch / distilling equipment'\n                         WHEN '218785' THEN 'Drug / drug equipment'\n                         WHEN '218786' THEN 'Mobile phone / mobile related item'\n                         WHEN '218787' THEN 'Digital find (excluding mobile phones)'\n                         WHEN '218788' THEN 'Tobacco / tobacco related items'\n                         WHEN '218789' THEN 'Weapon'\n                         WHEN '218790' THEN 'Other reportable items'\n                         WHEN '216784' THEN 'Multiple types'\n                         WHEN '216785' THEN 'Alcohol / hooch / distilling equipment'\n                         WHEN '216786' THEN 'Drug / drug equipment'\n                         WHEN '216787' THEN 'Mobile phone / mobile related item'\n                         WHEN '216788' THEN 'Digital find (excluding mobile phones)'\n                         WHEN '216789' THEN 'Tobacco / tobacco related items'\n                         WHEN '216790' THEN 'Weapon'\n                         WHEN '216791' THEN 'Other reportable items'\n                         END\n            END) AS find_category_new,\n\n        -- Legacy Find Logic Flags\n        MAX(CASE WHEN q.code IN ('49265','51234','51188','57288') AND res.code IN ('195011','198731','196731','209156') THEN 1 ELSE 0 END) AS found_drug,\n        MAX(CASE WHEN q.code IN ('49274','51242','51196','57296') AND res.code IN ('195045','198783','196783','209208') THEN 1 ELSE 0 END) AS found_mobile,\n        MAX(CASE WHEN q.code IN ('49289','51255','51209','57309') AND res.code IN ('195084','198874','196875','209297') THEN 1 ELSE 0 END) AS found_alcohol,\n\n        -- Flags for Assault Details\n        MAX(CASE WHEN (q.code = '61298' AND res.code = '213159') OR (q.code = '44773' AND res.code = '181164') THEN 'Y' END) AS is_serious,\n        MAX(CASE WHEN (q.code = '61305' AND res.code = '213197') OR (q.code = '44522' AND res.code = '180283') THEN 'Y' END) AS is_concussion,\n        MAX(CASE WHEN (q.code = '61285' AND res.code = '213111') OR (q.code = '44586' AND res.code = '180540') THEN 'Y' END) AS is_sexual,\n        MAX(CASE WHEN (q.code = '61300' AND res.code = '213173') OR (q.code = '44141' AND res.code = '178968') THEN 'Y' END) AS is_minor,\n        MAX(CASE WHEN (q.code = '61290' AND res.code = '213126') OR (q.code = '44464' AND res.code = '180077') THEN 'Y' END) AS is_spitting,\n\n        -- Flags for Self-Harm Details\n        MAX(CASE WHEN q.code = '44753' AND res.code = '181110' THEN 'Y' END) AS is_cutting,\n        MAX(CASE WHEN (q.code = '44244' AND res.code = '179302') OR (q.code = '44207' AND res.code = '179187') THEN 'Y' END) AS is_ligature,\n        MAX(CASE WHEN q.code = '45167' AND res.code = '182616' THEN 'Y' END) AS is_burning,\n\n        -- Text fields\n        MAX(CASE WHEN q.code = '61303' THEN\n                     CASE res.code\n                         WHEN '213182' THEN 'Accident and Emergency (A&E)'\n                         WHEN '213183' THEN 'Inpatient (overnight)'\n                         WHEN '213184' THEN 'Inpatient (over 24 hours)'\n                         WHEN '213185' THEN 'Life support'\n                         END\n            END) AS hospital_admission_type,\n        MAX(CASE WHEN (q.code = '61311' AND res.code = '213212') OR (q.code = '45074' AND res.code = '182269') THEN res.additional_information END) AS assault_reason,\n\n        -- FIND_6 Multiple types item detection (Q67205-67225 are exclusive to the Multiple flow)\n        MAX(CASE WHEN q.code = '67205' AND res.code != '218953' THEN 1 ELSE 0 END) AS f6m_alcohol,\n        MAX(CASE WHEN q.code = '67207' AND res.code = '218965' THEN 1 ELSE 0 END) AS f6m_drugs,\n        MAX(CASE WHEN q.code = '67213' AND res.code = '219014' THEN 1 ELSE 0 END) AS f6m_mobile,\n        MAX(CASE WHEN q.code = '67215' AND res.code != '219038' THEN 1 ELSE 0 END) AS f6m_sim,\n        MAX(CASE WHEN q.code = '67216' AND res.code != '219061' THEN 1 ELSE 0 END) AS f6m_memory,\n        MAX(CASE WHEN q.code = '67220' AND res.code != '219091' THEN 1 ELSE 0 END) AS f6m_digital,\n        MAX(CASE WHEN q.code = '67221' AND res.code = '219106' THEN 1 ELSE 0 END) AS f6m_tobacco,\n        MAX(CASE WHEN q.code = '67224' AND res.code != '219115' THEN 1 ELSE 0 END) AS f6m_weapon,\n        -- Incident location (where it took place) \u2014 covers active types + ASSAULT_1 legacy\n        MAX(CASE WHEN q.code IN ('61284', '45134', '45051', '67181', '63182', '49182', '44194', '100000', '44366', '44751', '44717', '45112', '45032', '44496', '44594', '44946', '45178', '45180', '44532', '44463', '44304', '44927') THEN\n            CASE res.code\n                -- ASSAULT_5 Q61284\n                WHEN '213074' THEN 'Administration'\n                WHEN '213075' THEN 'Association area' || COALESCE(' (' || NULLIF(res.additional_information, '') || ')', '')\n                WHEN '213076' THEN 'Cell' || COALESCE(' (' || NULLIF(res.additional_information, '') || ')', '')\n                WHEN '213077' THEN 'Chapel'\n                WHEN '213078' THEN 'Dining room'\n                WHEN '213079' THEN 'Dormitory'\n                WHEN '213080' THEN 'Education'\n                WHEN '213081' THEN 'Exercise yard'\n                WHEN '213082' THEN 'Gate'\n                WHEN '213083' THEN 'Gym'\n                WHEN '213084' THEN 'Health care centre'\n                WHEN '213085' THEN 'Kitchen'\n                WHEN '213086' THEN 'Office'\n                WHEN '213087' THEN 'Reception'\n                WHEN '213088' THEN 'Recess'\n                WHEN '213089' THEN 'Segregation unit'\n                WHEN '213090' THEN 'Special unit' || COALESCE(' (' || NULLIF(res.additional_information, '') || ')', '')\n                WHEN '213091' THEN 'Showers/changing room'\n                WHEN '213092' THEN 'Visits'\n                WHEN '213093' THEN 'Wing' || COALESCE(' (' || NULLIF(res.additional_information, '') || ')', '')\n                WHEN '213094' THEN 'Works department'\n                WHEN '213095' THEN 'Workshop' || COALESCE(' (' || NULLIF(res.additional_information, '') || ')', '')\n                WHEN '213096' THEN 'Within perimeter' || COALESCE(' (' || NULLIF(res.additional_information, '') || ')', '')\n                WHEN '213097' THEN 'Elsewhere' || COALESCE(' (' || NULLIF(res.additional_information, '') || ')', '')\n                WHEN '213098' THEN 'Funeral'\n                WHEN '213099' THEN 'Hospital outside (patient)'\n                WHEN '213100' THEN 'Hospital outside (visiting)'\n                WHEN '213101' THEN 'Outside working party' || COALESCE(' (' || NULLIF(res.additional_information, '') || ')', '')\n                WHEN '213102' THEN 'Sports field'\n                WHEN '213103' THEN 'Vehicle'\n                WHEN '213104' THEN 'Weddings'\n                WHEN '213105' THEN 'Magistrates court' || COALESCE(' (' || NULLIF(res.additional_information, '') || ')', '')\n                WHEN '213106' THEN 'Crown court' || COALESCE(' (' || NULLIF(res.additional_information, '') || ')', '')\n                WHEN '213107' THEN 'Induction/first night centre' || COALESCE(' (' || NULLIF(res.additional_information, '') || ')', '')\n                WHEN '213108' THEN 'Mail room'\n                WHEN '213109' THEN 'Vulnerable prisoners unit (VPU)' || COALESCE(' (' || NULLIF(res.additional_information, '') || ')', '')\n                WHEN '213110' THEN 'External roof' || COALESCE(' (' || NULLIF(res.additional_information, '') || ')', '')\n                -- ASSAULT_1 Q45134 (no comments on any response)\n                WHEN '182475' THEN 'Administration'\n                WHEN '182476' THEN 'Association area'\n                WHEN '182477' THEN 'Cell'\n                WHEN '182478' THEN 'Chapel'\n                WHEN '182479' THEN 'Crown court'\n                WHEN '182480' THEN 'Dining room'\n                WHEN '182481' THEN 'Dormitory'\n                WHEN '182482' THEN 'Education'\n                WHEN '182483' THEN 'Elsewhere'\n                WHEN '182484' THEN 'Exercise yard'\n                WHEN '182485' THEN 'Funeral'\n                WHEN '182486' THEN 'Gate'\n                WHEN '182487' THEN 'Gym'\n                WHEN '182488' THEN 'Health care centre'\n                WHEN '182489' THEN 'Hospital outside (patient)'\n                WHEN '182490' THEN 'Hospital outside (visiting)'\n                WHEN '182491' THEN 'Kitchen'\n                WHEN '182492' THEN 'Magistrates court'\n                WHEN '182493' THEN 'Office'\n                WHEN '182494' THEN 'Outside working party'\n                WHEN '182495' THEN 'Reception'\n                WHEN '182496' THEN 'Recess'\n                WHEN '182497' THEN 'Segregation unit'\n                WHEN '182498' THEN 'Showers/changing room'\n                WHEN '182499' THEN 'Special unit'\n                WHEN '182500' THEN 'Sports field'\n                WHEN '182501' THEN 'Vehicle'\n                WHEN '182502' THEN 'Visits'\n                WHEN '182503' THEN 'Weddings'\n                WHEN '182504' THEN 'Wing'\n                WHEN '182505' THEN 'Within perimeter'\n                WHEN '182506' THEN 'Works department'\n                WHEN '182507' THEN 'Workshop'\n                -- SELF_HARM_1 Q45051 (all have mandatory comment)\n                WHEN '182175' THEN 'Court cell' || COALESCE(' (' || NULLIF(res.additional_information, '') || ')', '')\n                WHEN '182176' THEN 'Detox unit' || COALESCE(' (' || NULLIF(res.additional_information, '') || ')', '')\n                WHEN '182177' THEN 'Health care centre' || COALESCE(' (' || NULLIF(res.additional_information, '') || ')', '')\n                WHEN '182178' THEN 'Indct''n/recp''n/1st nightcentre' || COALESCE(' (' || NULLIF(res.additional_information, '') || ')', '')\n                WHEN '182179' THEN 'Ordinary' || COALESCE(' (' || NULLIF(res.additional_information, '') || ')', '')\n                WHEN '182180' THEN 'Other' || COALESCE(' (' || NULLIF(res.additional_information, '') || ')', '')\n                WHEN '182181' THEN 'Prison escort vehicle' || COALESCE(' (' || NULLIF(res.additional_information, '') || ')', '')\n                WHEN '182182' THEN 'Segregation unit' || COALESCE(' (' || NULLIF(res.additional_information, '') || ')', '')\n                WHEN '182183' THEN 'VPU/other protected' || COALESCE(' (' || NULLIF(res.additional_information, '') || ')', '')\n                -- FIND_6 Q67181\n                WHEN '218712' THEN 'Administration'\n                WHEN '218713' THEN 'Association area' || COALESCE(' (' || NULLIF(res.additional_information, '') || ')', '')\n                WHEN '218714' THEN 'Cell' || COALESCE(' (' || NULLIF(res.additional_information, '') || ')', '')\n                WHEN '218715' THEN 'Chapel'\n                WHEN '218716' THEN 'Court'\n                WHEN '218717' THEN 'Dining room' || COALESCE(' (' || NULLIF(res.additional_information, '') || ')', '')\n                WHEN '218718' THEN 'Dormitory' || COALESCE(' (' || NULLIF(res.additional_information, '') || ')', '')\n                WHEN '218719' THEN 'Education'\n                WHEN '218720' THEN 'Exercise yard' || COALESCE(' (' || NULLIF(res.additional_information, '') || ')', '')\n                WHEN '218721' THEN 'Gate/gate lodge'\n                WHEN '218722' THEN 'Gym'\n                WHEN '218723' THEN 'Health care centre'\n                WHEN '218724' THEN 'Hospital outside (patient)'\n                WHEN '218725' THEN 'Hospital outside (visiting)'\n                WHEN '218726' THEN 'Induction/first night centre'\n                WHEN '218727' THEN 'Kitchen'\n                WHEN '218728' THEN 'Mail room'\n                WHEN '218729' THEN 'Office'\n                WHEN '218730' THEN 'Outside working party'\n                WHEN '218731' THEN 'Reception'\n                WHEN '218732' THEN 'Recess/ roof void'\n                WHEN '218733' THEN 'Segregation unit' || COALESCE(' (' || NULLIF(res.additional_information, '') || ')', '')\n                WHEN '218734' THEN 'Showers/changing room' || COALESCE(' (' || NULLIF(res.additional_information, '') || ')', '')\n                WHEN '218735' THEN 'Vehicle used for court/transfer'\n                WHEN '218736' THEN 'Visits'\n                WHEN '218737' THEN 'Vulnerable prisoners unit (VPU)' || COALESCE(' (' || NULLIF(res.additional_information, '') || ')', '')\n                WHEN '218738' THEN 'Wing' || COALESCE(' (' || NULLIF(res.additional_information, '') || ')', '')\n                WHEN '218739' THEN 'Workshop' || COALESCE(' (' || NULLIF(res.additional_information, '') || ')', '')\n                WHEN '218740' THEN 'Other' || COALESCE(' (' || NULLIF(res.additional_information, '') || ')', '')\n                -- DISORDER_2 Q63182 (all no comment except 214729)\n                WHEN '214694' THEN 'Administration'\n                WHEN '214695' THEN 'Association area'\n                WHEN '214696' THEN 'Cell'\n                WHEN '214697' THEN 'Chapel'\n                WHEN '214698' THEN 'Crown court'\n                WHEN '214699' THEN 'Dining room'\n                WHEN '214700' THEN 'Dormitory'\n                WHEN '214701' THEN 'Education'\n                WHEN '214702' THEN 'Exercise yard'\n                WHEN '214703' THEN 'External roof'\n                WHEN '214704' THEN 'Funeral'\n                WHEN '214705' THEN 'Gate'\n                WHEN '214706' THEN 'Gym'\n                WHEN '214707' THEN 'Health care centre'\n                WHEN '214708' THEN 'Hospital outside (patient)'\n                WHEN '214709' THEN 'Hospital outside (visiting)'\n                WHEN '214710' THEN 'Induction/1st night centre'\n                WHEN '214711' THEN 'Kitchen'\n                WHEN '214712' THEN 'Magistrates court'\n                WHEN '214713' THEN 'Office'\n                WHEN '214714' THEN 'Outside working party'\n                WHEN '214715' THEN 'Reception'\n                WHEN '214716' THEN 'Recess'\n                WHEN '214717' THEN 'Segregation unit'\n                WHEN '214718' THEN 'Showers/changing room'\n                WHEN '214719' THEN 'Special unit'\n                WHEN '214720' THEN 'Sports field'\n                WHEN '214721' THEN 'Vehicle'\n                WHEN '214722' THEN 'Visits'\n                WHEN '214723' THEN 'Vulnerable prisoners unit'\n                WHEN '214724' THEN 'Weddings'\n                WHEN '214725' THEN 'Wing'\n                WHEN '214726' THEN 'Within perimeter'\n                WHEN '214727' THEN 'Works department'\n                WHEN '214728' THEN 'Workshop'\n                WHEN '214729' THEN 'Other' || COALESCE(' (' || NULLIF(res.additional_information, '') || ')', '')\n                -- DISORDER_1 Q49182 (inactive, no comment except 194703)\n                WHEN '194695' THEN 'Administration'\n                WHEN '194696' THEN 'Association area'\n                WHEN '194697' THEN 'Cell'\n                WHEN '194698' THEN 'Chapel'\n                WHEN '194699' THEN 'Crown court'\n                WHEN '194700' THEN 'Dining room'\n                WHEN '194701' THEN 'Dormitory'\n                WHEN '194702' THEN 'Education'\n                WHEN '194703' THEN 'Elsewhere' || COALESCE(' (' || NULLIF(res.additional_information, '') || ')', '')\n                WHEN '194704' THEN 'Exercise yard'\n                WHEN '194705' THEN 'Funeral'\n                WHEN '194706' THEN 'Gate'\n                WHEN '194707' THEN 'Gym'\n                WHEN '194708' THEN 'Health care centre'\n                WHEN '194709' THEN 'Hospital outside (patient)'\n                WHEN '194710' THEN 'Hospital outside (visiting)'\n                WHEN '194711' THEN 'Kitchen'\n                WHEN '194712' THEN 'Magistrates court'\n                WHEN '194713' THEN 'Office'\n                WHEN '194714' THEN 'Outside working party'\n                WHEN '194715' THEN 'Reception'\n                WHEN '194716' THEN 'Recess'\n                WHEN '194717' THEN 'Segregation unit'\n                WHEN '194718' THEN 'Showers/changing room'\n                WHEN '194719' THEN 'Special unit'\n                WHEN '194720' THEN 'Sports field'\n                WHEN '194721' THEN 'Vehicle'\n                WHEN '194722' THEN 'Visits'\n                WHEN '194723' THEN 'Weddings'\n                WHEN '194724' THEN 'Wing'\n                WHEN '194725' THEN 'Within perimeter'\n                WHEN '194726' THEN 'Works department'\n                WHEN '194727' THEN 'Workshop'\n                WHEN '194728' THEN 'Induction/1st night centre'\n                WHEN '194729' THEN 'External roof'\n                WHEN '194730' THEN 'Vulnerable prisoners unit'\n                -- FIRE_1 Q44194\n                WHEN '179121' THEN 'Administration'\n                WHEN '179122' THEN 'Association area'\n                WHEN '179123' THEN 'Cell' || COALESCE(' (' || NULLIF(res.additional_information, '') || ')', '')\n                WHEN '179124' THEN 'Chapel'\n                WHEN '179126' THEN 'Dining room'\n                WHEN '179127' THEN 'Dormitory'\n                WHEN '179128' THEN 'Education'\n                WHEN '179130' THEN 'Exercise yard'\n                WHEN '179132' THEN 'Gate'\n                WHEN '179133' THEN 'Gym'\n                WHEN '179134' THEN 'Health care centre'\n                WHEN '179137' THEN 'Kitchen'\n                WHEN '179139' THEN 'Office'\n                WHEN '179141' THEN 'Reception'\n                WHEN '179142' THEN 'Recess'\n                WHEN '179143' THEN 'Segregation unit'\n                WHEN '179145' THEN 'Special unit'\n                WHEN '179144' THEN 'Showers/changing room'\n                WHEN '179148' THEN 'Visits'\n                WHEN '179150' THEN 'Wing'\n                WHEN '179152' THEN 'Works department'\n                WHEN '179153' THEN 'Workshop'\n                WHEN '179151' THEN 'Within perimeter'\n                WHEN '179129' THEN 'Elsewhere' || COALESCE(' (' || NULLIF(res.additional_information, '') || ')', '')\n                -- DIRTY_PROTEST_1 Q100000\n                WHEN '100001' THEN 'Ordinary cell' || COALESCE(' (' || NULLIF(res.additional_information, '') || ')', '')\n                WHEN '100002' THEN 'Specialist cell/unit' || COALESCE(' (' || NULLIF(res.additional_information, '') || ')', '')\n                WHEN '100003' THEN 'Shower/changing room' || COALESCE(' (' || NULLIF(res.additional_information, '') || ')', '')\n                WHEN '100004' THEN 'Other location within prison' || COALESCE(' (' || NULLIF(res.additional_information, '') || ')', '')\n                WHEN '100005' THEN 'Crown/magistrates court'\n                WHEN '100006' THEN 'Court cell'\n                WHEN '100007' THEN 'Vehicle' || COALESCE(' (' || NULLIF(res.additional_information, '') || ')', '')\n                -- DEATH_PRISONER_1 Q44366\n                WHEN '179724' THEN 'Single cell: ordinary location'\n                WHEN '179725' THEN 'Single cell: segregation unit'\n                WHEN '179723' THEN 'Shared cell: ordinary location'\n                WHEN '179727' THEN 'Special cell: segregation unit'\n                WHEN '179726' THEN 'Single cell: health care centre'\n                WHEN '179729' THEN 'Ward: health care centre'\n                WHEN '179728' THEN 'Unfurnished room: health care centre'\n                WHEN '179722' THEN 'Protective room: health care centre'\n                WHEN '179721' THEN 'Other' || COALESCE(' (' || NULLIF(res.additional_information, '') || ')', '')\n                -- DEATH_OTHER_1 Q44751 (single freetext response)\n                WHEN '181107' THEN NULLIF(res.additional_information, '')\n                -- ABSCOND_1 Q44717\n                WHEN '180993' THEN 'From establishment'\n                WHEN '180995' THEN 'Supervised outside party'\n                WHEN '180996' THEN 'Unsupervised outside party'\n                WHEN '180994' THEN 'Other' || COALESCE(' (' || NULLIF(res.additional_information, '') || ')', '')\n                -- ESCAPE_FROM_ESCORT_1 Q45112\n                WHEN '182389' THEN 'Vehicle en route to venue'\n                WHEN '182388' THEN 'Vehicle en route from venue'\n                WHEN '182387' THEN 'Leaving vehicle (debussing)'\n                WHEN '182386' THEN 'Entering vehicle (embussing)'\n                WHEN '182398' THEN 'Unscheduled stop'\n                WHEN '182390' THEN 'Cell at court'\n                WHEN '182391' THEN 'Court cells area'\n                WHEN '182393' THEN 'Court visits area'\n                WHEN '182392' THEN 'Court dock'\n                WHEN '182396' THEN 'Hospital ward/room'\n                WHEN '182394' THEN 'Hospital treatment room'\n                WHEN '182395' THEN 'Hospital waiting area'\n                WHEN '182397' THEN 'Other' || COALESCE(' (' || NULLIF(res.additional_information, '') || ')', '')\n                -- ESCAPE_FROM_PRISON_1 Q45032\n                WHEN '182064' THEN 'Sports field'\n                WHEN '182065' THEN 'Cell' || COALESCE(' (' || NULLIF(res.additional_information, '') || ')', '')\n                WHEN '182066' THEN 'Visits'\n                WHEN '182079' THEN 'Wing/houseblock'\n                WHEN '182069' THEN 'Dormitory'\n                WHEN '182074' THEN 'Health care centre'\n                WHEN '182068' THEN 'Chapel'\n                WHEN '182075' THEN 'Kitchen'\n                WHEN '182070' THEN 'Education/library'\n                WHEN '182081' THEN 'Workshop'\n                WHEN '182078' THEN 'Stores'\n                WHEN '182067' THEN 'Administration'\n                WHEN '182073' THEN 'Gymnasium'\n                WHEN '182077' THEN 'Reception'\n                WHEN '182080' THEN 'Works department'\n                WHEN '182071' THEN 'Exercise yard'\n                WHEN '182076' THEN 'Other secure area' || COALESCE(' (' || NULLIF(res.additional_information, '') || ')', '')\n                WHEN '182072' THEN 'Grounds with no access to external perimeter'\n                WHEN '182082' THEN 'Grounds with access to external perimeter'\n                -- ATTEMPTED_ESCAPE_FROM_ESCORT_1 Q44496\n                WHEN '180197' THEN 'Vehicle en route to venue'\n                WHEN '180196' THEN 'Vehicle en route from venue'\n                WHEN '180195' THEN 'Leaving vehicle (debussing)'\n                WHEN '180194' THEN 'Entering vehicle (embussing)'\n                WHEN '180206' THEN 'Unscheduled stop'\n                WHEN '180198' THEN 'Cell at court'\n                WHEN '180199' THEN 'Court cells area'\n                WHEN '180201' THEN 'Court visits area'\n                WHEN '180200' THEN 'Court dock'\n                WHEN '180204' THEN 'Hospital ward/room'\n                WHEN '180202' THEN 'Hospital treatment room'\n                WHEN '180203' THEN 'Hospital waiting area'\n                WHEN '180205' THEN 'Other' || COALESCE(' (' || NULLIF(res.additional_information, '') || ')', '')\n                -- ATTEMPTED_ESCAPE_FROM_PRISON_1 Q44594\n                WHEN '180572' THEN 'Sports field'\n                WHEN '180573' THEN 'Cell' || COALESCE(' (' || NULLIF(res.additional_information, '') || ')', '')\n                WHEN '180574' THEN 'Visits'\n                WHEN '180588' THEN 'Wing/houseblock'\n                WHEN '180577' THEN 'Dormitory'\n                WHEN '180583' THEN 'Health care centre'\n                WHEN '180576' THEN 'Chapel'\n                WHEN '180584' THEN 'Kitchen'\n                WHEN '180578' THEN 'Education/library'\n                WHEN '180590' THEN 'Workshop'\n                WHEN '180587' THEN 'Stores'\n                WHEN '180575' THEN 'Administration'\n                WHEN '180582' THEN 'Gymnasium'\n                WHEN '180586' THEN 'Reception'\n                WHEN '180589' THEN 'Works department'\n                WHEN '180579' THEN 'Exercise yard'\n                WHEN '180585' THEN 'Other secure area' || COALESCE(' (' || NULLIF(res.additional_information, '') || ')', '')\n                WHEN '180581' THEN 'Grounds with no access to external perimeter'\n                WHEN '180580' THEN 'Grounds with access to external perimeter'\n                -- BREACH_OF_SECURITY_1 Q44946\n                WHEN '181777' THEN 'Inside prison' || COALESCE(' (' || NULLIF(res.additional_information, '') || ')', '')\n                WHEN '181778' THEN 'Outside prison'\n                -- BOMB_1 Q45178\n                WHEN '182651' THEN 'Administration'\n                WHEN '182652' THEN 'Association area'\n                WHEN '182653' THEN 'Cell'\n                WHEN '182654' THEN 'Chapel'\n                WHEN '182655' THEN 'Crown court'\n                WHEN '182656' THEN 'Dining room'\n                WHEN '182657' THEN 'Dormitory'\n                WHEN '182658' THEN 'Education'\n                WHEN '182659' THEN 'Elsewhere' || COALESCE(' (' || NULLIF(res.additional_information, '') || ')', '')\n                WHEN '182660' THEN 'Exercise yard'\n                WHEN '182661' THEN 'Funeral'\n                WHEN '182662' THEN 'Gate'\n                WHEN '182663' THEN 'Gym'\n                WHEN '182664' THEN 'Health care centre'\n                WHEN '182665' THEN 'Hospital outside (patient)'\n                WHEN '182666' THEN 'Hospital outside (visiting)'\n                WHEN '182667' THEN 'Kitchen'\n                WHEN '182668' THEN 'Magistrates court'\n                WHEN '182669' THEN 'Office'\n                WHEN '182670' THEN 'Outside working party'\n                WHEN '182671' THEN 'Reception'\n                WHEN '182672' THEN 'Recess'\n                WHEN '182673' THEN 'Segregation unit'\n                WHEN '182674' THEN 'Showers/changing room'\n                WHEN '182675' THEN 'Special unit'\n                WHEN '182676' THEN 'Sports field'\n                WHEN '182677' THEN 'Vehicle'\n                WHEN '182678' THEN 'Visits'\n                WHEN '182679' THEN 'Weddings'\n                WHEN '182680' THEN 'Wing'\n                WHEN '182681' THEN 'Within perimeter'\n                WHEN '182682' THEN 'Works department'\n                WHEN '182683' THEN 'Workshop'\n                -- RELEASE_IN_ERROR_1 Q45180 (multipleAnswers, all mandatory comment)\n                WHEN '183026' THEN 'Establishment' || COALESCE(' (' || NULLIF(res.additional_information, '') || ')', '')\n                WHEN '183027' THEN 'Court' || COALESCE(' (' || NULLIF(res.additional_information, '') || ')', '')\n                WHEN '183028' THEN 'Other' || COALESCE(' (' || NULLIF(res.additional_information, '') || ')', '')\n                -- BARRICADE_1 Q44532 (inactive type, legacy)\n                WHEN '180354' THEN 'Administration'\n                WHEN '180355' THEN 'Association area'\n                WHEN '180356' THEN 'Cell'\n                WHEN '180357' THEN 'Chapel'\n                WHEN '180358' THEN 'Crown court'\n                WHEN '180359' THEN 'Dining room'\n                WHEN '180360' THEN 'Dormitory'\n                WHEN '180361' THEN 'Education'\n                WHEN '180362' THEN 'Elsewhere' || COALESCE(' (' || NULLIF(res.additional_information, '') || ')', '')\n                WHEN '180363' THEN 'Exercise yard'\n                WHEN '180364' THEN 'Funeral'\n                WHEN '180365' THEN 'Gate'\n                WHEN '180366' THEN 'Gym'\n                WHEN '180367' THEN 'Health care centre'\n                WHEN '180368' THEN 'Hospital outside (patient)'\n                WHEN '180369' THEN 'Hospital outside (visiting)'\n                WHEN '180370' THEN 'Kitchen'\n                WHEN '180371' THEN 'Magistrates court'\n                WHEN '180372' THEN 'Office'\n                WHEN '180373' THEN 'Outside working party'\n                WHEN '180374' THEN 'Reception'\n                WHEN '180375' THEN 'Recess'\n                WHEN '180376' THEN 'Segregation unit'\n                WHEN '180377' THEN 'Showers/changing room'\n                WHEN '180378' THEN 'Special unit'\n                WHEN '180379' THEN 'Sports field'\n                WHEN '180380' THEN 'Vehicle'\n                WHEN '180381' THEN 'Visits'\n                WHEN '180382' THEN 'Weddings'\n                WHEN '180383' THEN 'Wing'\n                WHEN '180384' THEN 'Within perimeter'\n                WHEN '180385' THEN 'Works department'\n                WHEN '180386' THEN 'Workshop'\n                -- HOSTAGE_1 Q44463 (inactive type, legacy)\n                WHEN '180034' THEN 'Administration'\n                WHEN '180035' THEN 'Association area'\n                WHEN '180036' THEN 'Cell'\n                WHEN '180037' THEN 'Chapel'\n                WHEN '180038' THEN 'Crown court'\n                WHEN '180039' THEN 'Dining room'\n                WHEN '180040' THEN 'Dormitory'\n                WHEN '180041' THEN 'Education'\n                WHEN '180042' THEN 'Elsewhere' || COALESCE(' (' || NULLIF(res.additional_information, '') || ')', '')\n                WHEN '180043' THEN 'Exercise yard'\n                WHEN '180044' THEN 'Funeral'\n                WHEN '180045' THEN 'Gate'\n                WHEN '180046' THEN 'Gym'\n                WHEN '180047' THEN 'Health care centre'\n                WHEN '180048' THEN 'Hospital outside (patient)'\n                WHEN '180049' THEN 'Hospital outside (visiting)'\n                WHEN '180050' THEN 'Kitchen'\n                WHEN '180051' THEN 'Magistrates court'\n                WHEN '180052' THEN 'Office'\n                WHEN '180053' THEN 'Outside working party'\n                WHEN '180054' THEN 'Reception'\n                WHEN '180055' THEN 'Recess'\n                WHEN '180056' THEN 'Segregation unit'\n                WHEN '180057' THEN 'Showers/changing room'\n                WHEN '180058' THEN 'Special unit'\n                WHEN '180059' THEN 'Sports field'\n                WHEN '180060' THEN 'Vehicle'\n                WHEN '180061' THEN 'Visits'\n                WHEN '180062' THEN 'Weddings'\n                WHEN '180063' THEN 'Wing'\n                WHEN '180064' THEN 'Within perimeter'\n                WHEN '180065' THEN 'Works department'\n                WHEN '180066' THEN 'Workshop'\n                -- CONCERTED_INDISCIPLINE_1 Q44304 (inactive type, legacy)\n                WHEN '179481' THEN 'Administration'\n                WHEN '179482' THEN 'Association area'\n                WHEN '179483' THEN 'Cell'\n                WHEN '179484' THEN 'Chapel'\n                WHEN '179485' THEN 'Crown court'\n                WHEN '179486' THEN 'Dining room'\n                WHEN '179487' THEN 'Dormitory'\n                WHEN '179488' THEN 'Education'\n                WHEN '179489' THEN 'Elsewhere' || COALESCE(' (' || NULLIF(res.additional_information, '') || ')', '')\n                WHEN '179490' THEN 'Exercise yard'\n                WHEN '179491' THEN 'Funeral'\n                WHEN '179492' THEN 'Gate'\n                WHEN '179493' THEN 'Gym'\n                WHEN '179494' THEN 'Health care centre'\n                WHEN '179495' THEN 'Hospital outside (patient)'\n                WHEN '179496' THEN 'Hospital outside (visiting)'\n                WHEN '179497' THEN 'Kitchen'\n                WHEN '179498' THEN 'Magistrates court'\n                WHEN '179499' THEN 'Office'\n                WHEN '179500' THEN 'Outside working party'\n                WHEN '179501' THEN 'Reception'\n                WHEN '179502' THEN 'Recess'\n                WHEN '179503' THEN 'Segregation unit'\n                WHEN '179504' THEN 'Showers/changing room'\n                WHEN '179505' THEN 'Special unit'\n                WHEN '179506' THEN 'Sports field'\n                WHEN '179507' THEN 'Vehicle'\n                WHEN '179508' THEN 'Visits'\n                WHEN '179509' THEN 'Weddings'\n                WHEN '179510' THEN 'Wing'\n                WHEN '179511' THEN 'Within perimeter'\n                WHEN '179512' THEN 'Works department'\n                WHEN '179513' THEN 'Workshop'\n                -- INCIDENT_AT_HEIGHT_1 Q44927 (inactive type, legacy)\n                WHEN '181684' THEN 'Administration'\n                WHEN '181685' THEN 'Association area'\n                WHEN '181686' THEN 'Cell'\n                WHEN '181687' THEN 'Chapel'\n                WHEN '181688' THEN 'Crown court'\n                WHEN '181689' THEN 'Dining room'\n                WHEN '181690' THEN 'Dormitory'\n                WHEN '181691' THEN 'Education'\n                WHEN '181692' THEN 'Elsewhere' || COALESCE(' (' || NULLIF(res.additional_information, '') || ')', '')\n                WHEN '181693' THEN 'Exercise yard'\n                WHEN '181694' THEN 'Funeral'\n                WHEN '181695' THEN 'Gate'\n                WHEN '181696' THEN 'Gym'\n                WHEN '181697' THEN 'Health care centre'\n                WHEN '181698' THEN 'Hospital outside (patient)'\n                WHEN '181699' THEN 'Hospital outside (visiting)'\n                WHEN '181700' THEN 'Kitchen'\n                WHEN '181701' THEN 'Magistrates court'\n                WHEN '181702' THEN 'Office'\n                WHEN '181703' THEN 'Outside working party'\n                WHEN '181704' THEN 'Reception'\n                WHEN '181705' THEN 'Recess'\n                WHEN '181706' THEN 'Segregation unit'\n                WHEN '181707' THEN 'Showers/changing room'\n                WHEN '181708' THEN 'Special unit'\n                WHEN '181709' THEN 'Sports field'\n                WHEN '181710' THEN 'Vehicle'\n                WHEN '181711' THEN 'Visits'\n                WHEN '181712' THEN 'Weddings'\n                WHEN '181713' THEN 'Wing'\n                WHEN '181714' THEN 'Within perimeter'\n                WHEN '181715' THEN 'Works department'\n                WHEN '181716' THEN 'Workshop'\n            END\n        END) AS incident_location\n\n    FROM prisons.incidentreporting_question q\n             JOIN prisons.incidentreporting_response res ON res.question_id = q.id\n    GROUP BY 1\n)\n\nSELECT\n    r.id,\n    r.report_reference,\n    r.location,\n    p.name AS location_name,\n    al.noms_region_code AS region_code,\n    area.description AS region_name,\n    ctf.code AS type,\n    ct.description AS type_description,\n\n    -- incident_subtype logic refactored\n    CASE\n        WHEN ctf.code = 'ASSAULT' THEN qa.assault_subtype\n        WHEN ctf.code = 'BARRICADE' THEN 'Barricade'\n        WHEN ctf.code = 'CONCERTED_INDISCIPLINE' THEN 'Concerted Indiscipline'\n        WHEN ctf.code = 'HOSTAGE' THEN 'Hostage'\n        WHEN ctf.code = 'INCIDENT_AT_HEIGHT' THEN 'Incident at Height'\n        WHEN ctf.code = 'DISORDER' THEN 'Disorder'\n        WHEN ctf.code = 'FIND' THEN\n            COALESCE(qa.find_category_new,\n                     CASE\n                         WHEN (qa.found_drug + qa.found_mobile + qa.found_alcohol) > 1 THEN 'Multiple types'\n                         WHEN qa.found_drug = 1 THEN 'Drug / drug equipment'\n                         WHEN qa.found_mobile = 1 THEN 'Mobile phone / mobile related item'\n                         WHEN qa.found_alcohol = 1 THEN 'Alcohol / hooch / distilling equipment'\n                         END\n            )\n        END AS incident_subtype,\n\n    r.status,\n    cs.description AS status_description,\n    r.incident_date_and_time,\n    r.reported_by,\n    INITCAP(pi.first_name) AS first_name,\n    INITCAP(pi.last_name) AS last_name,\n    pi.prisoner_number,\n    cpr.description AS prisoner_role,\n    pi.comment AS prisoner_comment,\n\n    -- Assault Extra Info\n    CASE WHEN ctf.code = 'ASSAULT' THEN COALESCE(qa.is_serious, 'N') END AS serious_injury,\n    CASE WHEN ctf.code = 'ASSAULT' THEN COALESCE(qa.is_concussion, 'N') END AS concussion_treatment,\n    qa.hospital_admission_type,\n    CASE WHEN ctf.code = 'ASSAULT' THEN COALESCE(qa.is_sexual, 'N') END AS sexual_assault,\n    CASE WHEN ctf.code = 'ASSAULT' THEN COALESCE(qa.is_minor, 'N') END AS minor_assault,\n    CASE WHEN ctf.code = 'ASSAULT' THEN COALESCE(qa.is_spitting, 'N') END AS spitting,\n    qa.assault_reason,\n\n    -- Self-Harm Extra Info\n    CASE WHEN ctf.code = 'SELF_HARM' THEN COALESCE(qa.is_cutting, 'N') END AS cutting,\n    CASE WHEN ctf.code = 'SELF_HARM' THEN COALESCE(qa.is_ligature, 'N') END AS strangulation_or_hanging,\n    CASE WHEN ctf.code = 'SELF_HARM' THEN COALESCE(qa.is_burning, 'N') END AS burning,\n\n    -- Finds Extra Info\n    CASE WHEN ctf.code = 'FIND' THEN\n        NULLIF(REGEXP_REPLACE(\n            CASE WHEN COALESCE(qa.f6m_alcohol, 0) = 1 OR COALESCE(qa.found_alcohol, 0) = 1 THEN 'Alcohol, ' ELSE '' END ||\n            CASE WHEN COALESCE(qa.f6m_drugs, 0) = 1 OR COALESCE(qa.found_drug, 0) = 1 THEN 'Drugs, ' ELSE '' END ||\n            CASE WHEN COALESCE(qa.f6m_mobile, 0) = 1 OR COALESCE(qa.found_mobile, 0) = 1 THEN 'Mobile phone, ' ELSE '' END ||\n            CASE WHEN COALESCE(qa.f6m_sim, 0) = 1 THEN 'SIM card, ' ELSE '' END ||\n            CASE WHEN COALESCE(qa.f6m_memory, 0) = 1 THEN 'Memory card, ' ELSE '' END ||\n            CASE WHEN COALESCE(qa.f6m_digital, 0) = 1 THEN 'Digital, ' ELSE '' END ||\n            CASE WHEN COALESCE(qa.f6m_tobacco, 0) = 1 THEN 'Tobacco, ' ELSE '' END ||\n            CASE WHEN COALESCE(qa.f6m_weapon, 0) = 1 THEN 'Weapon, ' ELSE '' END\n        , ',\\\\s*$', ''), '')\n    END AS finds_detail,\n\n    qa.incident_location,\n    -- Incident summary: key facts for the incident type in plain words\n    CASE\n        WHEN ctf.code = 'ASSAULT' THEN\n            NULLIF(REGEXP_REPLACE(\n                CASE WHEN COALESCE(qa.is_serious, 'N') = 'Y' THEN 'Serious injury, ' ELSE '' END ||\n                CASE WHEN COALESCE(qa.is_sexual, 'N') = 'Y' THEN 'Sexual assault, ' ELSE '' END ||\n                CASE WHEN COALESCE(qa.is_minor, 'N') = 'Y' THEN 'Minor assault, ' ELSE '' END ||\n                CASE WHEN COALESCE(qa.is_spitting, 'N') = 'Y' THEN 'Spitting, ' ELSE '' END ||\n                CASE WHEN COALESCE(qa.is_concussion, 'N') = 'Y' THEN 'Concussion treatment, ' ELSE '' END ||\n                CASE WHEN qa.hospital_admission_type IS NOT NULL THEN qa.hospital_admission_type || ', ' ELSE '' END\n            , ',\\\\s*$', ''), '')\n        WHEN ctf.code = 'SELF_HARM' THEN\n            NULLIF(REGEXP_REPLACE(\n                CASE WHEN COALESCE(qa.is_cutting, 'N') = 'Y' THEN 'Cutting, ' ELSE '' END ||\n                CASE WHEN COALESCE(qa.is_ligature, 'N') = 'Y' THEN 'Strangulation or hanging, ' ELSE '' END ||\n                CASE WHEN COALESCE(qa.is_burning, 'N') = 'Y' THEN 'Burning, ' ELSE '' END\n            , ',\\\\s*$', ''), '')\n        WHEN ctf.code = 'FIND' THEN\n            NULLIF(REGEXP_REPLACE(\n                CASE WHEN COALESCE(qa.f6m_alcohol, 0) = 1 OR COALESCE(qa.found_alcohol, 0) = 1 THEN 'Alcohol, ' ELSE '' END ||\n                CASE WHEN COALESCE(qa.f6m_drugs, 0) = 1 OR COALESCE(qa.found_drug, 0) = 1 THEN 'Drugs, ' ELSE '' END ||\n                CASE WHEN COALESCE(qa.f6m_mobile, 0) = 1 OR COALESCE(qa.found_mobile, 0) = 1 THEN 'Mobile phone, ' ELSE '' END ||\n                CASE WHEN COALESCE(qa.f6m_sim, 0) = 1 THEN 'SIM card, ' ELSE '' END ||\n                CASE WHEN COALESCE(qa.f6m_memory, 0) = 1 THEN 'Memory card, ' ELSE '' END ||\n                CASE WHEN COALESCE(qa.f6m_digital, 0) = 1 THEN 'Digital, ' ELSE '' END ||\n                CASE WHEN COALESCE(qa.f6m_tobacco, 0) = 1 THEN 'Tobacco, ' ELSE '' END ||\n                CASE WHEN COALESCE(qa.f6m_weapon, 0) = 1 THEN 'Weapon, ' ELSE '' END\n            , ',\\\\s*$', ''), '')\n    END AS incident_summary\n\nFROM prisons.incidentreporting_prisoner_involvement pi\n         JOIN prisons.incidentreporting_report r ON r.id = pi.report_id\n         JOIN prisons.incidentreporting_constant_status cs ON r.status = cs.code\n         JOIN prisons.incidentreporting_constant_type ct ON r.type = ct.code\n         JOIN prisons.incidentreporting_constant_type_family ctf ON ctf.code = ct.family_code\n         JOIN prisons.incidentreporting_constant_prisoner_role cpr ON cpr.code = pi.prisoner_role\n         JOIN prisons.prisonregister_prison p ON p.prison_id = r.location\n         JOIN prisons.nomis_agency_locations al ON al.agy_loc_id = p.prison_id\n         LEFT JOIN prisons.nomis_areas area ON area.area_class = 'REGION' AND area.area_code = al.noms_region_code\n         LEFT JOIN qa_pivoted qa ON qa.report_id = r.id\n\nWHERE r.status NOT IN ('DUPLICATE', 'NOT_REPORTABLE', 'DRAFT')",
+      "schema": {
+        "field": [
+          {
+            "name": "id",
+            "type": "string"
+          },
+          {
+            "name": "report_reference",
+            "type": "string"
+          },
+          {
+            "name": "type",
+            "type": "string",
+            "filter": {
+              "type": "multiselect",
+              "dynamicoptions": {
+                "maximumOptions": 60,
+                "returnAsStaticOptions": true,
+                "dataset": "types",
+                "name": "code",
+                "display": "description"
+              }
+            }
+          },
+          {
+            "name": "type_description",
+            "type": "string"
+          },
+          {
+            "name": "status",
+            "type": "string",
+            "filter": {
+              "type": "multiselect",
+              "interactive": true,
+              "dynamicoptions": {
+                "maximumOptions": 20,
+                "returnAsStaticOptions": true,
+                "dataset": "status",
+                "name": "code",
+                "display": "description"
+              }
+            }
+          },
+          {
+            "name": "status_description",
+            "type": "string"
+          },
+          {
+            "name": "incident_date_and_time",
+            "type": "datetime"
+          },
+          {
+            "name": "reported_by",
+            "type": "string"
+          },
+          {
+            "name": "first_name",
+            "type": "string"
+          },
+          {
+            "name": "last_name",
+            "type": "string"
+          },
+          {
+            "name": "prisoner_number",
+            "type": "string"
+          },
+          {
+            "name": "prisoner_role",
+            "type": "string"
+          },
+          {
+            "name": "prisoner_comment",
+            "type": "string"
+          },
+          {
+            "name": "location",
+            "type": "string"
+          },
+          {
+            "name": "location_name",
+            "type": "string"
+          },
+          {
+            "name": "region_code",
+            "type": "string"
+          },
+          {
+            "name": "region_name",
+            "type": "string"
+          },
+          {
+            "name": "incident_subtype",
+            "type": "string"
+          },
+          {
+            "name": "serious_injury",
+            "type": "string"
+          },
+          {
+            "name": "concussion_treatment",
+            "type": "string"
+          },
+          {
+            "name": "hospital_admission_type",
+            "type": "string"
+          },
+          {
+            "name": "sexual_assault",
+            "type": "string"
+          },
+          {
+            "name": "minor_assault",
+            "type": "string"
+          },
+          {
+            "name": "spitting",
+            "type": "string"
+          },
+          {
+            "name": "assault_reason",
+            "type": "string"
+          },
+          {
+            "name": "cutting",
+            "type": "string"
+          },
+          {
+            "name": "strangulation_or_hanging",
+            "type": "string"
+          },
+          {
+            "name": "burning",
+            "type": "string"
+          },
+          {
+            "name": "finds_detail",
+            "type": "string"
+          },
+          {
+            "name": "incident_location",
+            "type": "string"
+          },
+          {
+            "name": "incident_summary",
             "type": "string"
           }
         ]
@@ -2128,6 +2284,387 @@
             "defaultsort": true,
             "sortdirection": "desc",
             "formula": "make_url('https://incident-reporting-${env}.hmpps.service.justice.gov.uk/reports?searchID=${prisoner_number}',${total_incidents},TRUE)"
+          }
+        ]
+      },
+      "destination": []
+    },
+    {
+      "id": "prisoner-incident-detail",
+      "name": "Prisoner Involvement in Incidents: Establishment Level",
+      "description": "Shows each prisoner involved in a reported incident alongside their role, any comments recorded against them, and the where the incident took place. For key incident types, structured Q&A detail is surfaced as additional columns: assault severity flags (serious, sexual, minor, spitting, concussion treatment, hospital admission, and reason); self-harm method flags (cutting, strangulation/hanging, burning); and for finds, a comma-separated list of items identified.",
+      "version": "1.0.0",
+      "dataset": "$ref:prisoner-incident-detail",
+      "render": "HTML",
+      "feature": [
+        {
+          "type": "print"
+        }
+      ],
+      "metadata": {
+        "hints": [
+          "interactive"
+        ]
+      },
+      "specification": {
+        "template": "list",
+        "field": [
+          {
+            "name": "$ref:prisoner_number",
+            "display": "Prisoner number",
+            "sortable": true,
+            "formula": "make_url('https://prisoner-${env}.digital.prison.service.justice.gov.uk/prisoner/${prisoner_number}',${prisoner_number},TRUE)",
+            "visible": "true",
+            "defaultsort": false,
+            "filter": {
+              "type": "text"
+            }
+          },
+          {
+            "name": "$ref:last_name",
+            "formula": "${last_name}, ${first_name}",
+            "display": "Name",
+            "sortable": true,
+            "visible": "true",
+            "defaultsort": false
+          },
+          {
+            "name": "$ref:report_reference",
+            "display": "Incident number",
+            "sortable": true,
+            "formula": "make_url('https://incident-reporting-${env}.hmpps.service.justice.gov.uk/reports/${id}',${report_reference},TRUE)",
+            "visible": "true",
+            "defaultsort": false
+          },
+          {
+            "name": "$ref:incident_date_and_time",
+            "display": "Date of incident",
+            "formula": "format_date(${incident_date_and_time}, 'dd/MM/yyyy HH:mm')",
+            "sortable": true,
+            "visible": "true",
+            "defaultsort": true,
+            "sortdirection": "desc",
+            "filter": {
+              "type": "daterange",
+              "default": "today(-1,months) - today()"
+            }
+          },
+          {
+            "name": "$ref:type",
+            "display": "Type code",
+            "sortable": true,
+            "visible": "false",
+            "defaultsort": false
+          },
+          {
+            "name": "$ref:type_description",
+            "display": "Incident type",
+            "sortable": true,
+            "visible": "true",
+            "defaultsort": false
+          },
+          {
+            "name": "$ref:status",
+            "display": "Status code",
+            "sortable": false,
+            "visible": "false",
+            "defaultsort": false
+          },
+          {
+            "name": "$ref:status_description",
+            "display": "Incident status",
+            "sortable": true,
+            "visible": "true",
+            "defaultsort": false
+          },
+          {
+            "name": "$ref:location",
+            "display": "Location",
+            "sortable": true,
+            "visible": "false",
+            "defaultsort": false,
+            "filter": {
+              "type": "multiselect",
+              "mandatory": false,
+              "dynamicoptions": {
+                "maximumOptions": 140,
+                "returnAsStaticOptions": true,
+                "dataset": "prisons",
+                "name": "prison_id",
+                "display": "prison_name"
+              }
+            }
+          },
+          {
+            "name": "$ref:location_name",
+            "display": "Location name",
+            "sortable": true,
+            "visible": "true",
+            "defaultsort": false
+          },
+          {
+            "name": "$ref:incident_subtype",
+            "display": "Subtype",
+            "sortable": true,
+            "visible": "true",
+            "defaultsort": false,
+            "filter": {
+              "type": "multiselect",
+              "mandatory": false,
+              "staticoptions": [
+                {
+                  "name": "Prisoner on prisoner (PoP)",
+                  "display": "Prisoner on prisoner (PoP)"
+                },
+                {
+                  "name": "Prisoner on staff (PoS)",
+                  "display": "Prisoner on staff (PoS)"
+                },
+                {
+                  "name": "Prisoner on other",
+                  "display": "Prisoner on other"
+                },
+                {
+                  "name": "Other",
+                  "display": "Other"
+                }
+              ]
+            }
+          },
+          {
+            "name": "$ref:region_code",
+            "display": "Region",
+            "sortable": true,
+            "visible": "false",
+            "defaultsort": false,
+            "filter": {
+              "type": "multiselect",
+              "mandatory": false,
+              "dynamicoptions": {
+                "maximumOptions": 20,
+                "returnAsStaticOptions": true,
+                "dataset": "regionCodes",
+                "name": "code",
+                "display": "description"
+              }
+            }
+          },
+          {
+            "name": "$ref:region_name",
+            "display": "Region name",
+            "sortable": true,
+            "visible": "false",
+            "defaultsort": false
+          },
+          {
+            "name": "$ref:prisoner_role",
+            "display": "Prisoner role",
+            "sortable": false,
+            "visible": "true",
+            "defaultsort": false,
+            "filter": {
+              "type": "multiselect",
+              "mandatory": false,
+              "dynamicoptions": {
+                "maximumOptions": 20,
+                "returnAsStaticOptions": true,
+                "dataset": "prisoner_role",
+                "name": "description",
+                "display": "description"
+              }
+            }
+          },
+          {
+            "name": "$ref:incident_location",
+            "display": "Incident location",
+            "sortable": false,
+            "visible": "true",
+            "defaultsort": false
+          },
+          {
+            "name": "$ref:incident_summary",
+            "display": "Incident summary",
+            "sortable": false,
+            "visible": "true",
+            "defaultsort": false
+          },
+          {
+            "name": "$ref:prisoner_comment",
+            "display": "Prisoner comment",
+            "sortable": false,
+            "visible": "true",
+            "defaultsort": false
+          },
+          {
+            "name": "$ref:assault_reason",
+            "display": "Assault reason",
+            "sortable": false,
+            "visible": "true"
+          },
+          {
+            "name": "$ref:serious_injury",
+            "display": "Serious injury",
+            "sortable": false,
+            "visible": "false",
+            "filter": {
+              "type": "radio",
+              "staticoptions": [
+                {
+                  "name": "Y",
+                  "display": "Serious injury"
+                },
+                {
+                  "name": "N",
+                  "display": "Non serious injury"
+                }
+              ]
+            }
+          },
+          {
+            "name": "$ref:concussion_treatment",
+            "display": "Concussion treatment",
+            "sortable": false,
+            "visible": "false",
+            "filter": {
+              "type": "radio",
+              "staticoptions": [
+                {
+                  "name": "Y",
+                  "display": "Concussion"
+                },
+                {
+                  "name": "N",
+                  "display": "No concussion"
+                }
+              ]
+            }
+          },
+          {
+            "name": "$ref:hospital_admission_type",
+            "display": "Hospital admission type",
+            "sortable": false,
+            "visible": "true"
+          },
+          {
+            "name": "$ref:sexual_assault",
+            "display": "Sexual assault",
+            "sortable": false,
+            "visible": "false",
+            "filter": {
+              "type": "radio",
+              "staticoptions": [
+                {
+                  "name": "Y",
+                  "display": "Sexual assault"
+                },
+                {
+                  "name": "N",
+                  "display": "Non-sexual assault"
+                }
+              ]
+            }
+          },
+          {
+            "name": "$ref:minor_assault",
+            "display": "Minor assault",
+            "sortable": false,
+            "visible": "false",
+            "filter": {
+              "type": "radio",
+              "staticoptions": [
+                {
+                  "name": "Y",
+                  "display": "Minor assault"
+                },
+                {
+                  "name": "N",
+                  "display": "Not a minor assault"
+                }
+              ]
+            }
+          },
+          {
+            "name": "$ref:spitting",
+            "display": "Spitting",
+            "sortable": false,
+            "visible": "false",
+            "filter": {
+              "type": "radio",
+              "staticoptions": [
+                {
+                  "name": "Y",
+                  "display": "Spitting involved"
+                },
+                {
+                  "name": "N",
+                  "display": "Spitting not involved"
+                }
+              ]
+            }
+          },
+          {
+            "name": "$ref:cutting",
+            "display": "Cutting",
+            "sortable": false,
+            "visible": "false",
+            "filter": {
+              "type": "radio",
+              "staticoptions": [
+                {
+                  "name": "Y",
+                  "display": "Cutting involved"
+                },
+                {
+                  "name": "N",
+                  "display": "Cutting not involved"
+                }
+              ]
+            }
+          },
+          {
+            "name": "$ref:strangulation_or_hanging",
+            "display": "Strangulation or hanging",
+            "sortable": false,
+            "visible": "false",
+            "filter": {
+              "type": "radio",
+              "staticoptions": [
+                {
+                  "name": "Y",
+                  "display": "Strangulation or hanging involved"
+                },
+                {
+                  "name": "N",
+                  "display": "No strangulation or hanging involved"
+                }
+              ]
+            }
+          },
+          {
+            "name": "$ref:burning",
+            "display": "Burning",
+            "sortable": false,
+            "visible": "false",
+            "filter": {
+              "type": "radio",
+              "staticoptions": [
+                {
+                  "name": "Y",
+                  "display": "Burning involved"
+                },
+                {
+                  "name": "N",
+                  "display": "No burning involved"
+                }
+              ]
+            }
+          },
+          {
+            "name": "$ref:finds_detail",
+            "display": "Finds detail",
+            "sortable": false,
+            "visible": "true",
+            "defaultsort": false
           }
         ]
       },

--- a/dpd/test/definitions/prisons/orphanage/incident-report.json
+++ b/dpd/test/definitions/prisons/orphanage/incident-report.json
@@ -8,13 +8,14 @@
     "version": "1.0.0",
     "owner": "Managing Safety",
     "tags": [
-      "DPS", "Incident Reporting"
+      "DPS",
+      "Incident Reporting"
     ]
   },
   "datasource": [
     {
-      "id" : "datamart",
-      "name" : "datamart"
+      "id": "datamart",
+      "name": "datamart"
     }
   ],
   "policy": [
@@ -802,6 +803,161 @@
           },
           {
             "name": "other_method",
+            "type": "string"
+          }
+        ]
+      }
+    },
+    {
+      "id": "prisoner-incident-detail",
+      "name": "Prisoner Involvement in Incidents: Establishment Level",
+      "datasource": "datamart",
+      "query": "WITH qa_pivoted AS (\n    -- We scan the Q&A tables once and pivot all required answers into a single row per report\n    SELECT\n        q.report_id,\n\n        -- Assault Subtypes\n        MAX(CASE WHEN q.code IN ('61287', '44367') THEN\n                     CASE res.code\n                         WHEN '213115' THEN 'Prisoner on prisoner (PoP)'\n                         WHEN '213116' THEN 'Prisoner on staff (PoS)'\n                         WHEN '213117' THEN 'Prisoner on other'\n                         WHEN '213118' THEN 'Other'\n                         WHEN '179730' THEN 'Prisoner on prisoner (PoP)'\n                         WHEN '179732' THEN 'Prisoner on officer (PoS)'\n                         WHEN '179733' THEN 'Prisoner on other'\n                         WHEN '179731' THEN 'Other'\n                         END\n            END) AS assault_subtype,\n\n        -- Find Categories (Newer Versions)\n        MAX(CASE WHEN q.code IN ('67187', '65187') THEN\n                     CASE res.code\n                         WHEN '218783' THEN 'Multiple types'\n                         WHEN '218784' THEN 'Alcohol / hooch / distilling equipment'\n                         WHEN '218785' THEN 'Drug / drug equipment'\n                         WHEN '218786' THEN 'Mobile phone / mobile related item'\n                         WHEN '218787' THEN 'Digital find (excluding mobile phones)'\n                         WHEN '218788' THEN 'Tobacco / tobacco related items'\n                         WHEN '218789' THEN 'Weapon'\n                         WHEN '218790' THEN 'Other reportable items'\n                         WHEN '216784' THEN 'Multiple types'\n                         WHEN '216785' THEN 'Alcohol / hooch / distilling equipment'\n                         WHEN '216786' THEN 'Drug / drug equipment'\n                         WHEN '216787' THEN 'Mobile phone / mobile related item'\n                         WHEN '216788' THEN 'Digital find (excluding mobile phones)'\n                         WHEN '216789' THEN 'Tobacco / tobacco related items'\n                         WHEN '216790' THEN 'Weapon'\n                         WHEN '216791' THEN 'Other reportable items'\n                         END\n            END) AS find_category_new,\n\n        -- Legacy Find Logic Flags\n        MAX(CASE WHEN q.code IN ('49265','51234','51188','57288') AND res.code IN ('195011','198731','196731','209156') THEN 1 ELSE 0 END) AS found_drug,\n        MAX(CASE WHEN q.code IN ('49274','51242','51196','57296') AND res.code IN ('195045','198783','196783','209208') THEN 1 ELSE 0 END) AS found_mobile,\n        MAX(CASE WHEN q.code IN ('49289','51255','51209','57309') AND res.code IN ('195084','198874','196875','209297') THEN 1 ELSE 0 END) AS found_alcohol,\n\n        -- Flags for Assault Details\n        MAX(CASE WHEN (q.code = '61298' AND res.code = '213159') OR (q.code = '44773' AND res.code = '181164') THEN 'Y' END) AS is_serious,\n        MAX(CASE WHEN (q.code = '61305' AND res.code = '213197') OR (q.code = '44522' AND res.code = '180283') THEN 'Y' END) AS is_concussion,\n        MAX(CASE WHEN (q.code = '61285' AND res.code = '213111') OR (q.code = '44586' AND res.code = '180540') THEN 'Y' END) AS is_sexual,\n        MAX(CASE WHEN (q.code = '61300' AND res.code = '213173') OR (q.code = '44141' AND res.code = '178968') THEN 'Y' END) AS is_minor,\n        MAX(CASE WHEN (q.code = '61290' AND res.code = '213126') OR (q.code = '44464' AND res.code = '180077') THEN 'Y' END) AS is_spitting,\n\n        -- Flags for Self-Harm Details\n        MAX(CASE WHEN q.code = '44753' AND res.code = '181110' THEN 'Y' END) AS is_cutting,\n        MAX(CASE WHEN (q.code = '44244' AND res.code = '179302') OR (q.code = '44207' AND res.code = '179187') THEN 'Y' END) AS is_ligature,\n        MAX(CASE WHEN q.code = '45167' AND res.code = '182616' THEN 'Y' END) AS is_burning,\n\n        -- Text fields\n        MAX(CASE WHEN q.code = '61303' THEN\n                     CASE res.code\n                         WHEN '213182' THEN 'Accident and Emergency (A&E)'\n                         WHEN '213183' THEN 'Inpatient (overnight)'\n                         WHEN '213184' THEN 'Inpatient (over 24 hours)'\n                         WHEN '213185' THEN 'Life support'\n                         END\n            END) AS hospital_admission_type,\n        MAX(CASE WHEN (q.code = '61311' AND res.code = '213212') OR (q.code = '45074' AND res.code = '182269') THEN res.additional_information END) AS assault_reason,\n\n        -- FIND_6 Multiple types item detection (Q67205-67225 are exclusive to the Multiple flow)\n        MAX(CASE WHEN q.code = '67205' AND res.code != '218953' THEN 1 ELSE 0 END) AS f6m_alcohol,\n        MAX(CASE WHEN q.code = '67207' AND res.code = '218965' THEN 1 ELSE 0 END) AS f6m_drugs,\n        MAX(CASE WHEN q.code = '67213' AND res.code = '219014' THEN 1 ELSE 0 END) AS f6m_mobile,\n        MAX(CASE WHEN q.code = '67215' AND res.code != '219038' THEN 1 ELSE 0 END) AS f6m_sim,\n        MAX(CASE WHEN q.code = '67216' AND res.code != '219061' THEN 1 ELSE 0 END) AS f6m_memory,\n        MAX(CASE WHEN q.code = '67220' AND res.code != '219091' THEN 1 ELSE 0 END) AS f6m_digital,\n        MAX(CASE WHEN q.code = '67221' AND res.code = '219106' THEN 1 ELSE 0 END) AS f6m_tobacco,\n        MAX(CASE WHEN q.code = '67224' AND res.code != '219115' THEN 1 ELSE 0 END) AS f6m_weapon,\n        -- Incident location (where it took place) \u2014 covers active types + ASSAULT_1 legacy\n        MAX(CASE WHEN q.code IN ('61284', '45134', '45051', '67181', '63182', '49182', '44194', '100000', '44366', '44751', '44717', '45112', '45032', '44496', '44594', '44946', '45178', '45180', '44532', '44463', '44304', '44927') THEN\n            CASE res.code\n                -- ASSAULT_5 Q61284\n                WHEN '213074' THEN 'Administration'\n                WHEN '213075' THEN 'Association area' || COALESCE(' (' || NULLIF(res.additional_information, '') || ')', '')\n                WHEN '213076' THEN 'Cell' || COALESCE(' (' || NULLIF(res.additional_information, '') || ')', '')\n                WHEN '213077' THEN 'Chapel'\n                WHEN '213078' THEN 'Dining room'\n                WHEN '213079' THEN 'Dormitory'\n                WHEN '213080' THEN 'Education'\n                WHEN '213081' THEN 'Exercise yard'\n                WHEN '213082' THEN 'Gate'\n                WHEN '213083' THEN 'Gym'\n                WHEN '213084' THEN 'Health care centre'\n                WHEN '213085' THEN 'Kitchen'\n                WHEN '213086' THEN 'Office'\n                WHEN '213087' THEN 'Reception'\n                WHEN '213088' THEN 'Recess'\n                WHEN '213089' THEN 'Segregation unit'\n                WHEN '213090' THEN 'Special unit' || COALESCE(' (' || NULLIF(res.additional_information, '') || ')', '')\n                WHEN '213091' THEN 'Showers/changing room'\n                WHEN '213092' THEN 'Visits'\n                WHEN '213093' THEN 'Wing' || COALESCE(' (' || NULLIF(res.additional_information, '') || ')', '')\n                WHEN '213094' THEN 'Works department'\n                WHEN '213095' THEN 'Workshop' || COALESCE(' (' || NULLIF(res.additional_information, '') || ')', '')\n                WHEN '213096' THEN 'Within perimeter' || COALESCE(' (' || NULLIF(res.additional_information, '') || ')', '')\n                WHEN '213097' THEN 'Elsewhere' || COALESCE(' (' || NULLIF(res.additional_information, '') || ')', '')\n                WHEN '213098' THEN 'Funeral'\n                WHEN '213099' THEN 'Hospital outside (patient)'\n                WHEN '213100' THEN 'Hospital outside (visiting)'\n                WHEN '213101' THEN 'Outside working party' || COALESCE(' (' || NULLIF(res.additional_information, '') || ')', '')\n                WHEN '213102' THEN 'Sports field'\n                WHEN '213103' THEN 'Vehicle'\n                WHEN '213104' THEN 'Weddings'\n                WHEN '213105' THEN 'Magistrates court' || COALESCE(' (' || NULLIF(res.additional_information, '') || ')', '')\n                WHEN '213106' THEN 'Crown court' || COALESCE(' (' || NULLIF(res.additional_information, '') || ')', '')\n                WHEN '213107' THEN 'Induction/first night centre' || COALESCE(' (' || NULLIF(res.additional_information, '') || ')', '')\n                WHEN '213108' THEN 'Mail room'\n                WHEN '213109' THEN 'Vulnerable prisoners unit (VPU)' || COALESCE(' (' || NULLIF(res.additional_information, '') || ')', '')\n                WHEN '213110' THEN 'External roof' || COALESCE(' (' || NULLIF(res.additional_information, '') || ')', '')\n                -- ASSAULT_1 Q45134 (no comments on any response)\n                WHEN '182475' THEN 'Administration'\n                WHEN '182476' THEN 'Association area'\n                WHEN '182477' THEN 'Cell'\n                WHEN '182478' THEN 'Chapel'\n                WHEN '182479' THEN 'Crown court'\n                WHEN '182480' THEN 'Dining room'\n                WHEN '182481' THEN 'Dormitory'\n                WHEN '182482' THEN 'Education'\n                WHEN '182483' THEN 'Elsewhere'\n                WHEN '182484' THEN 'Exercise yard'\n                WHEN '182485' THEN 'Funeral'\n                WHEN '182486' THEN 'Gate'\n                WHEN '182487' THEN 'Gym'\n                WHEN '182488' THEN 'Health care centre'\n                WHEN '182489' THEN 'Hospital outside (patient)'\n                WHEN '182490' THEN 'Hospital outside (visiting)'\n                WHEN '182491' THEN 'Kitchen'\n                WHEN '182492' THEN 'Magistrates court'\n                WHEN '182493' THEN 'Office'\n                WHEN '182494' THEN 'Outside working party'\n                WHEN '182495' THEN 'Reception'\n                WHEN '182496' THEN 'Recess'\n                WHEN '182497' THEN 'Segregation unit'\n                WHEN '182498' THEN 'Showers/changing room'\n                WHEN '182499' THEN 'Special unit'\n                WHEN '182500' THEN 'Sports field'\n                WHEN '182501' THEN 'Vehicle'\n                WHEN '182502' THEN 'Visits'\n                WHEN '182503' THEN 'Weddings'\n                WHEN '182504' THEN 'Wing'\n                WHEN '182505' THEN 'Within perimeter'\n                WHEN '182506' THEN 'Works department'\n                WHEN '182507' THEN 'Workshop'\n                -- SELF_HARM_1 Q45051 (all have mandatory comment)\n                WHEN '182175' THEN 'Court cell' || COALESCE(' (' || NULLIF(res.additional_information, '') || ')', '')\n                WHEN '182176' THEN 'Detox unit' || COALESCE(' (' || NULLIF(res.additional_information, '') || ')', '')\n                WHEN '182177' THEN 'Health care centre' || COALESCE(' (' || NULLIF(res.additional_information, '') || ')', '')\n                WHEN '182178' THEN 'Indct''n/recp''n/1st nightcentre' || COALESCE(' (' || NULLIF(res.additional_information, '') || ')', '')\n                WHEN '182179' THEN 'Ordinary' || COALESCE(' (' || NULLIF(res.additional_information, '') || ')', '')\n                WHEN '182180' THEN 'Other' || COALESCE(' (' || NULLIF(res.additional_information, '') || ')', '')\n                WHEN '182181' THEN 'Prison escort vehicle' || COALESCE(' (' || NULLIF(res.additional_information, '') || ')', '')\n                WHEN '182182' THEN 'Segregation unit' || COALESCE(' (' || NULLIF(res.additional_information, '') || ')', '')\n                WHEN '182183' THEN 'VPU/other protected' || COALESCE(' (' || NULLIF(res.additional_information, '') || ')', '')\n                -- FIND_6 Q67181\n                WHEN '218712' THEN 'Administration'\n                WHEN '218713' THEN 'Association area' || COALESCE(' (' || NULLIF(res.additional_information, '') || ')', '')\n                WHEN '218714' THEN 'Cell' || COALESCE(' (' || NULLIF(res.additional_information, '') || ')', '')\n                WHEN '218715' THEN 'Chapel'\n                WHEN '218716' THEN 'Court'\n                WHEN '218717' THEN 'Dining room' || COALESCE(' (' || NULLIF(res.additional_information, '') || ')', '')\n                WHEN '218718' THEN 'Dormitory' || COALESCE(' (' || NULLIF(res.additional_information, '') || ')', '')\n                WHEN '218719' THEN 'Education'\n                WHEN '218720' THEN 'Exercise yard' || COALESCE(' (' || NULLIF(res.additional_information, '') || ')', '')\n                WHEN '218721' THEN 'Gate/gate lodge'\n                WHEN '218722' THEN 'Gym'\n                WHEN '218723' THEN 'Health care centre'\n                WHEN '218724' THEN 'Hospital outside (patient)'\n                WHEN '218725' THEN 'Hospital outside (visiting)'\n                WHEN '218726' THEN 'Induction/first night centre'\n                WHEN '218727' THEN 'Kitchen'\n                WHEN '218728' THEN 'Mail room'\n                WHEN '218729' THEN 'Office'\n                WHEN '218730' THEN 'Outside working party'\n                WHEN '218731' THEN 'Reception'\n                WHEN '218732' THEN 'Recess/ roof void'\n                WHEN '218733' THEN 'Segregation unit' || COALESCE(' (' || NULLIF(res.additional_information, '') || ')', '')\n                WHEN '218734' THEN 'Showers/changing room' || COALESCE(' (' || NULLIF(res.additional_information, '') || ')', '')\n                WHEN '218735' THEN 'Vehicle used for court/transfer'\n                WHEN '218736' THEN 'Visits'\n                WHEN '218737' THEN 'Vulnerable prisoners unit (VPU)' || COALESCE(' (' || NULLIF(res.additional_information, '') || ')', '')\n                WHEN '218738' THEN 'Wing' || COALESCE(' (' || NULLIF(res.additional_information, '') || ')', '')\n                WHEN '218739' THEN 'Workshop' || COALESCE(' (' || NULLIF(res.additional_information, '') || ')', '')\n                WHEN '218740' THEN 'Other' || COALESCE(' (' || NULLIF(res.additional_information, '') || ')', '')\n                -- DISORDER_2 Q63182 (all no comment except 214729)\n                WHEN '214694' THEN 'Administration'\n                WHEN '214695' THEN 'Association area'\n                WHEN '214696' THEN 'Cell'\n                WHEN '214697' THEN 'Chapel'\n                WHEN '214698' THEN 'Crown court'\n                WHEN '214699' THEN 'Dining room'\n                WHEN '214700' THEN 'Dormitory'\n                WHEN '214701' THEN 'Education'\n                WHEN '214702' THEN 'Exercise yard'\n                WHEN '214703' THEN 'External roof'\n                WHEN '214704' THEN 'Funeral'\n                WHEN '214705' THEN 'Gate'\n                WHEN '214706' THEN 'Gym'\n                WHEN '214707' THEN 'Health care centre'\n                WHEN '214708' THEN 'Hospital outside (patient)'\n                WHEN '214709' THEN 'Hospital outside (visiting)'\n                WHEN '214710' THEN 'Induction/1st night centre'\n                WHEN '214711' THEN 'Kitchen'\n                WHEN '214712' THEN 'Magistrates court'\n                WHEN '214713' THEN 'Office'\n                WHEN '214714' THEN 'Outside working party'\n                WHEN '214715' THEN 'Reception'\n                WHEN '214716' THEN 'Recess'\n                WHEN '214717' THEN 'Segregation unit'\n                WHEN '214718' THEN 'Showers/changing room'\n                WHEN '214719' THEN 'Special unit'\n                WHEN '214720' THEN 'Sports field'\n                WHEN '214721' THEN 'Vehicle'\n                WHEN '214722' THEN 'Visits'\n                WHEN '214723' THEN 'Vulnerable prisoners unit'\n                WHEN '214724' THEN 'Weddings'\n                WHEN '214725' THEN 'Wing'\n                WHEN '214726' THEN 'Within perimeter'\n                WHEN '214727' THEN 'Works department'\n                WHEN '214728' THEN 'Workshop'\n                WHEN '214729' THEN 'Other' || COALESCE(' (' || NULLIF(res.additional_information, '') || ')', '')\n                -- DISORDER_1 Q49182 (inactive, no comment except 194703)\n                WHEN '194695' THEN 'Administration'\n                WHEN '194696' THEN 'Association area'\n                WHEN '194697' THEN 'Cell'\n                WHEN '194698' THEN 'Chapel'\n                WHEN '194699' THEN 'Crown court'\n                WHEN '194700' THEN 'Dining room'\n                WHEN '194701' THEN 'Dormitory'\n                WHEN '194702' THEN 'Education'\n                WHEN '194703' THEN 'Elsewhere' || COALESCE(' (' || NULLIF(res.additional_information, '') || ')', '')\n                WHEN '194704' THEN 'Exercise yard'\n                WHEN '194705' THEN 'Funeral'\n                WHEN '194706' THEN 'Gate'\n                WHEN '194707' THEN 'Gym'\n                WHEN '194708' THEN 'Health care centre'\n                WHEN '194709' THEN 'Hospital outside (patient)'\n                WHEN '194710' THEN 'Hospital outside (visiting)'\n                WHEN '194711' THEN 'Kitchen'\n                WHEN '194712' THEN 'Magistrates court'\n                WHEN '194713' THEN 'Office'\n                WHEN '194714' THEN 'Outside working party'\n                WHEN '194715' THEN 'Reception'\n                WHEN '194716' THEN 'Recess'\n                WHEN '194717' THEN 'Segregation unit'\n                WHEN '194718' THEN 'Showers/changing room'\n                WHEN '194719' THEN 'Special unit'\n                WHEN '194720' THEN 'Sports field'\n                WHEN '194721' THEN 'Vehicle'\n                WHEN '194722' THEN 'Visits'\n                WHEN '194723' THEN 'Weddings'\n                WHEN '194724' THEN 'Wing'\n                WHEN '194725' THEN 'Within perimeter'\n                WHEN '194726' THEN 'Works department'\n                WHEN '194727' THEN 'Workshop'\n                WHEN '194728' THEN 'Induction/1st night centre'\n                WHEN '194729' THEN 'External roof'\n                WHEN '194730' THEN 'Vulnerable prisoners unit'\n                -- FIRE_1 Q44194\n                WHEN '179121' THEN 'Administration'\n                WHEN '179122' THEN 'Association area'\n                WHEN '179123' THEN 'Cell' || COALESCE(' (' || NULLIF(res.additional_information, '') || ')', '')\n                WHEN '179124' THEN 'Chapel'\n                WHEN '179126' THEN 'Dining room'\n                WHEN '179127' THEN 'Dormitory'\n                WHEN '179128' THEN 'Education'\n                WHEN '179130' THEN 'Exercise yard'\n                WHEN '179132' THEN 'Gate'\n                WHEN '179133' THEN 'Gym'\n                WHEN '179134' THEN 'Health care centre'\n                WHEN '179137' THEN 'Kitchen'\n                WHEN '179139' THEN 'Office'\n                WHEN '179141' THEN 'Reception'\n                WHEN '179142' THEN 'Recess'\n                WHEN '179143' THEN 'Segregation unit'\n                WHEN '179145' THEN 'Special unit'\n                WHEN '179144' THEN 'Showers/changing room'\n                WHEN '179148' THEN 'Visits'\n                WHEN '179150' THEN 'Wing'\n                WHEN '179152' THEN 'Works department'\n                WHEN '179153' THEN 'Workshop'\n                WHEN '179151' THEN 'Within perimeter'\n                WHEN '179129' THEN 'Elsewhere' || COALESCE(' (' || NULLIF(res.additional_information, '') || ')', '')\n                -- DIRTY_PROTEST_1 Q100000\n                WHEN '100001' THEN 'Ordinary cell' || COALESCE(' (' || NULLIF(res.additional_information, '') || ')', '')\n                WHEN '100002' THEN 'Specialist cell/unit' || COALESCE(' (' || NULLIF(res.additional_information, '') || ')', '')\n                WHEN '100003' THEN 'Shower/changing room' || COALESCE(' (' || NULLIF(res.additional_information, '') || ')', '')\n                WHEN '100004' THEN 'Other location within prison' || COALESCE(' (' || NULLIF(res.additional_information, '') || ')', '')\n                WHEN '100005' THEN 'Crown/magistrates court'\n                WHEN '100006' THEN 'Court cell'\n                WHEN '100007' THEN 'Vehicle' || COALESCE(' (' || NULLIF(res.additional_information, '') || ')', '')\n                -- DEATH_PRISONER_1 Q44366\n                WHEN '179724' THEN 'Single cell: ordinary location'\n                WHEN '179725' THEN 'Single cell: segregation unit'\n                WHEN '179723' THEN 'Shared cell: ordinary location'\n                WHEN '179727' THEN 'Special cell: segregation unit'\n                WHEN '179726' THEN 'Single cell: health care centre'\n                WHEN '179729' THEN 'Ward: health care centre'\n                WHEN '179728' THEN 'Unfurnished room: health care centre'\n                WHEN '179722' THEN 'Protective room: health care centre'\n                WHEN '179721' THEN 'Other' || COALESCE(' (' || NULLIF(res.additional_information, '') || ')', '')\n                -- DEATH_OTHER_1 Q44751 (single freetext response)\n                WHEN '181107' THEN NULLIF(res.additional_information, '')\n                -- ABSCOND_1 Q44717\n                WHEN '180993' THEN 'From establishment'\n                WHEN '180995' THEN 'Supervised outside party'\n                WHEN '180996' THEN 'Unsupervised outside party'\n                WHEN '180994' THEN 'Other' || COALESCE(' (' || NULLIF(res.additional_information, '') || ')', '')\n                -- ESCAPE_FROM_ESCORT_1 Q45112\n                WHEN '182389' THEN 'Vehicle en route to venue'\n                WHEN '182388' THEN 'Vehicle en route from venue'\n                WHEN '182387' THEN 'Leaving vehicle (debussing)'\n                WHEN '182386' THEN 'Entering vehicle (embussing)'\n                WHEN '182398' THEN 'Unscheduled stop'\n                WHEN '182390' THEN 'Cell at court'\n                WHEN '182391' THEN 'Court cells area'\n                WHEN '182393' THEN 'Court visits area'\n                WHEN '182392' THEN 'Court dock'\n                WHEN '182396' THEN 'Hospital ward/room'\n                WHEN '182394' THEN 'Hospital treatment room'\n                WHEN '182395' THEN 'Hospital waiting area'\n                WHEN '182397' THEN 'Other' || COALESCE(' (' || NULLIF(res.additional_information, '') || ')', '')\n                -- ESCAPE_FROM_PRISON_1 Q45032\n                WHEN '182064' THEN 'Sports field'\n                WHEN '182065' THEN 'Cell' || COALESCE(' (' || NULLIF(res.additional_information, '') || ')', '')\n                WHEN '182066' THEN 'Visits'\n                WHEN '182079' THEN 'Wing/houseblock'\n                WHEN '182069' THEN 'Dormitory'\n                WHEN '182074' THEN 'Health care centre'\n                WHEN '182068' THEN 'Chapel'\n                WHEN '182075' THEN 'Kitchen'\n                WHEN '182070' THEN 'Education/library'\n                WHEN '182081' THEN 'Workshop'\n                WHEN '182078' THEN 'Stores'\n                WHEN '182067' THEN 'Administration'\n                WHEN '182073' THEN 'Gymnasium'\n                WHEN '182077' THEN 'Reception'\n                WHEN '182080' THEN 'Works department'\n                WHEN '182071' THEN 'Exercise yard'\n                WHEN '182076' THEN 'Other secure area' || COALESCE(' (' || NULLIF(res.additional_information, '') || ')', '')\n                WHEN '182072' THEN 'Grounds with no access to external perimeter'\n                WHEN '182082' THEN 'Grounds with access to external perimeter'\n                -- ATTEMPTED_ESCAPE_FROM_ESCORT_1 Q44496\n                WHEN '180197' THEN 'Vehicle en route to venue'\n                WHEN '180196' THEN 'Vehicle en route from venue'\n                WHEN '180195' THEN 'Leaving vehicle (debussing)'\n                WHEN '180194' THEN 'Entering vehicle (embussing)'\n                WHEN '180206' THEN 'Unscheduled stop'\n                WHEN '180198' THEN 'Cell at court'\n                WHEN '180199' THEN 'Court cells area'\n                WHEN '180201' THEN 'Court visits area'\n                WHEN '180200' THEN 'Court dock'\n                WHEN '180204' THEN 'Hospital ward/room'\n                WHEN '180202' THEN 'Hospital treatment room'\n                WHEN '180203' THEN 'Hospital waiting area'\n                WHEN '180205' THEN 'Other' || COALESCE(' (' || NULLIF(res.additional_information, '') || ')', '')\n                -- ATTEMPTED_ESCAPE_FROM_PRISON_1 Q44594\n                WHEN '180572' THEN 'Sports field'\n                WHEN '180573' THEN 'Cell' || COALESCE(' (' || NULLIF(res.additional_information, '') || ')', '')\n                WHEN '180574' THEN 'Visits'\n                WHEN '180588' THEN 'Wing/houseblock'\n                WHEN '180577' THEN 'Dormitory'\n                WHEN '180583' THEN 'Health care centre'\n                WHEN '180576' THEN 'Chapel'\n                WHEN '180584' THEN 'Kitchen'\n                WHEN '180578' THEN 'Education/library'\n                WHEN '180590' THEN 'Workshop'\n                WHEN '180587' THEN 'Stores'\n                WHEN '180575' THEN 'Administration'\n                WHEN '180582' THEN 'Gymnasium'\n                WHEN '180586' THEN 'Reception'\n                WHEN '180589' THEN 'Works department'\n                WHEN '180579' THEN 'Exercise yard'\n                WHEN '180585' THEN 'Other secure area' || COALESCE(' (' || NULLIF(res.additional_information, '') || ')', '')\n                WHEN '180581' THEN 'Grounds with no access to external perimeter'\n                WHEN '180580' THEN 'Grounds with access to external perimeter'\n                -- BREACH_OF_SECURITY_1 Q44946\n                WHEN '181777' THEN 'Inside prison' || COALESCE(' (' || NULLIF(res.additional_information, '') || ')', '')\n                WHEN '181778' THEN 'Outside prison'\n                -- BOMB_1 Q45178\n                WHEN '182651' THEN 'Administration'\n                WHEN '182652' THEN 'Association area'\n                WHEN '182653' THEN 'Cell'\n                WHEN '182654' THEN 'Chapel'\n                WHEN '182655' THEN 'Crown court'\n                WHEN '182656' THEN 'Dining room'\n                WHEN '182657' THEN 'Dormitory'\n                WHEN '182658' THEN 'Education'\n                WHEN '182659' THEN 'Elsewhere' || COALESCE(' (' || NULLIF(res.additional_information, '') || ')', '')\n                WHEN '182660' THEN 'Exercise yard'\n                WHEN '182661' THEN 'Funeral'\n                WHEN '182662' THEN 'Gate'\n                WHEN '182663' THEN 'Gym'\n                WHEN '182664' THEN 'Health care centre'\n                WHEN '182665' THEN 'Hospital outside (patient)'\n                WHEN '182666' THEN 'Hospital outside (visiting)'\n                WHEN '182667' THEN 'Kitchen'\n                WHEN '182668' THEN 'Magistrates court'\n                WHEN '182669' THEN 'Office'\n                WHEN '182670' THEN 'Outside working party'\n                WHEN '182671' THEN 'Reception'\n                WHEN '182672' THEN 'Recess'\n                WHEN '182673' THEN 'Segregation unit'\n                WHEN '182674' THEN 'Showers/changing room'\n                WHEN '182675' THEN 'Special unit'\n                WHEN '182676' THEN 'Sports field'\n                WHEN '182677' THEN 'Vehicle'\n                WHEN '182678' THEN 'Visits'\n                WHEN '182679' THEN 'Weddings'\n                WHEN '182680' THEN 'Wing'\n                WHEN '182681' THEN 'Within perimeter'\n                WHEN '182682' THEN 'Works department'\n                WHEN '182683' THEN 'Workshop'\n                -- RELEASE_IN_ERROR_1 Q45180 (multipleAnswers, all mandatory comment)\n                WHEN '183026' THEN 'Establishment' || COALESCE(' (' || NULLIF(res.additional_information, '') || ')', '')\n                WHEN '183027' THEN 'Court' || COALESCE(' (' || NULLIF(res.additional_information, '') || ')', '')\n                WHEN '183028' THEN 'Other' || COALESCE(' (' || NULLIF(res.additional_information, '') || ')', '')\n                -- BARRICADE_1 Q44532 (inactive type, legacy)\n                WHEN '180354' THEN 'Administration'\n                WHEN '180355' THEN 'Association area'\n                WHEN '180356' THEN 'Cell'\n                WHEN '180357' THEN 'Chapel'\n                WHEN '180358' THEN 'Crown court'\n                WHEN '180359' THEN 'Dining room'\n                WHEN '180360' THEN 'Dormitory'\n                WHEN '180361' THEN 'Education'\n                WHEN '180362' THEN 'Elsewhere' || COALESCE(' (' || NULLIF(res.additional_information, '') || ')', '')\n                WHEN '180363' THEN 'Exercise yard'\n                WHEN '180364' THEN 'Funeral'\n                WHEN '180365' THEN 'Gate'\n                WHEN '180366' THEN 'Gym'\n                WHEN '180367' THEN 'Health care centre'\n                WHEN '180368' THEN 'Hospital outside (patient)'\n                WHEN '180369' THEN 'Hospital outside (visiting)'\n                WHEN '180370' THEN 'Kitchen'\n                WHEN '180371' THEN 'Magistrates court'\n                WHEN '180372' THEN 'Office'\n                WHEN '180373' THEN 'Outside working party'\n                WHEN '180374' THEN 'Reception'\n                WHEN '180375' THEN 'Recess'\n                WHEN '180376' THEN 'Segregation unit'\n                WHEN '180377' THEN 'Showers/changing room'\n                WHEN '180378' THEN 'Special unit'\n                WHEN '180379' THEN 'Sports field'\n                WHEN '180380' THEN 'Vehicle'\n                WHEN '180381' THEN 'Visits'\n                WHEN '180382' THEN 'Weddings'\n                WHEN '180383' THEN 'Wing'\n                WHEN '180384' THEN 'Within perimeter'\n                WHEN '180385' THEN 'Works department'\n                WHEN '180386' THEN 'Workshop'\n                -- HOSTAGE_1 Q44463 (inactive type, legacy)\n                WHEN '180034' THEN 'Administration'\n                WHEN '180035' THEN 'Association area'\n                WHEN '180036' THEN 'Cell'\n                WHEN '180037' THEN 'Chapel'\n                WHEN '180038' THEN 'Crown court'\n                WHEN '180039' THEN 'Dining room'\n                WHEN '180040' THEN 'Dormitory'\n                WHEN '180041' THEN 'Education'\n                WHEN '180042' THEN 'Elsewhere' || COALESCE(' (' || NULLIF(res.additional_information, '') || ')', '')\n                WHEN '180043' THEN 'Exercise yard'\n                WHEN '180044' THEN 'Funeral'\n                WHEN '180045' THEN 'Gate'\n                WHEN '180046' THEN 'Gym'\n                WHEN '180047' THEN 'Health care centre'\n                WHEN '180048' THEN 'Hospital outside (patient)'\n                WHEN '180049' THEN 'Hospital outside (visiting)'\n                WHEN '180050' THEN 'Kitchen'\n                WHEN '180051' THEN 'Magistrates court'\n                WHEN '180052' THEN 'Office'\n                WHEN '180053' THEN 'Outside working party'\n                WHEN '180054' THEN 'Reception'\n                WHEN '180055' THEN 'Recess'\n                WHEN '180056' THEN 'Segregation unit'\n                WHEN '180057' THEN 'Showers/changing room'\n                WHEN '180058' THEN 'Special unit'\n                WHEN '180059' THEN 'Sports field'\n                WHEN '180060' THEN 'Vehicle'\n                WHEN '180061' THEN 'Visits'\n                WHEN '180062' THEN 'Weddings'\n                WHEN '180063' THEN 'Wing'\n                WHEN '180064' THEN 'Within perimeter'\n                WHEN '180065' THEN 'Works department'\n                WHEN '180066' THEN 'Workshop'\n                -- CONCERTED_INDISCIPLINE_1 Q44304 (inactive type, legacy)\n                WHEN '179481' THEN 'Administration'\n                WHEN '179482' THEN 'Association area'\n                WHEN '179483' THEN 'Cell'\n                WHEN '179484' THEN 'Chapel'\n                WHEN '179485' THEN 'Crown court'\n                WHEN '179486' THEN 'Dining room'\n                WHEN '179487' THEN 'Dormitory'\n                WHEN '179488' THEN 'Education'\n                WHEN '179489' THEN 'Elsewhere' || COALESCE(' (' || NULLIF(res.additional_information, '') || ')', '')\n                WHEN '179490' THEN 'Exercise yard'\n                WHEN '179491' THEN 'Funeral'\n                WHEN '179492' THEN 'Gate'\n                WHEN '179493' THEN 'Gym'\n                WHEN '179494' THEN 'Health care centre'\n                WHEN '179495' THEN 'Hospital outside (patient)'\n                WHEN '179496' THEN 'Hospital outside (visiting)'\n                WHEN '179497' THEN 'Kitchen'\n                WHEN '179498' THEN 'Magistrates court'\n                WHEN '179499' THEN 'Office'\n                WHEN '179500' THEN 'Outside working party'\n                WHEN '179501' THEN 'Reception'\n                WHEN '179502' THEN 'Recess'\n                WHEN '179503' THEN 'Segregation unit'\n                WHEN '179504' THEN 'Showers/changing room'\n                WHEN '179505' THEN 'Special unit'\n                WHEN '179506' THEN 'Sports field'\n                WHEN '179507' THEN 'Vehicle'\n                WHEN '179508' THEN 'Visits'\n                WHEN '179509' THEN 'Weddings'\n                WHEN '179510' THEN 'Wing'\n                WHEN '179511' THEN 'Within perimeter'\n                WHEN '179512' THEN 'Works department'\n                WHEN '179513' THEN 'Workshop'\n                -- INCIDENT_AT_HEIGHT_1 Q44927 (inactive type, legacy)\n                WHEN '181684' THEN 'Administration'\n                WHEN '181685' THEN 'Association area'\n                WHEN '181686' THEN 'Cell'\n                WHEN '181687' THEN 'Chapel'\n                WHEN '181688' THEN 'Crown court'\n                WHEN '181689' THEN 'Dining room'\n                WHEN '181690' THEN 'Dormitory'\n                WHEN '181691' THEN 'Education'\n                WHEN '181692' THEN 'Elsewhere' || COALESCE(' (' || NULLIF(res.additional_information, '') || ')', '')\n                WHEN '181693' THEN 'Exercise yard'\n                WHEN '181694' THEN 'Funeral'\n                WHEN '181695' THEN 'Gate'\n                WHEN '181696' THEN 'Gym'\n                WHEN '181697' THEN 'Health care centre'\n                WHEN '181698' THEN 'Hospital outside (patient)'\n                WHEN '181699' THEN 'Hospital outside (visiting)'\n                WHEN '181700' THEN 'Kitchen'\n                WHEN '181701' THEN 'Magistrates court'\n                WHEN '181702' THEN 'Office'\n                WHEN '181703' THEN 'Outside working party'\n                WHEN '181704' THEN 'Reception'\n                WHEN '181705' THEN 'Recess'\n                WHEN '181706' THEN 'Segregation unit'\n                WHEN '181707' THEN 'Showers/changing room'\n                WHEN '181708' THEN 'Special unit'\n                WHEN '181709' THEN 'Sports field'\n                WHEN '181710' THEN 'Vehicle'\n                WHEN '181711' THEN 'Visits'\n                WHEN '181712' THEN 'Weddings'\n                WHEN '181713' THEN 'Wing'\n                WHEN '181714' THEN 'Within perimeter'\n                WHEN '181715' THEN 'Works department'\n                WHEN '181716' THEN 'Workshop'\n            END\n        END) AS incident_location\n\n    FROM prisons.incidentreporting_question q\n             JOIN prisons.incidentreporting_response res ON res.question_id = q.id\n    GROUP BY 1\n)\n\nSELECT\n    r.id,\n    r.report_reference,\n    r.location,\n    p.name AS location_name,\n    al.noms_region_code AS region_code,\n    area.description AS region_name,\n    ctf.code AS type,\n    ct.description AS type_description,\n\n    -- incident_subtype logic refactored\n    CASE\n        WHEN ctf.code = 'ASSAULT' THEN qa.assault_subtype\n        WHEN ctf.code = 'BARRICADE' THEN 'Barricade'\n        WHEN ctf.code = 'CONCERTED_INDISCIPLINE' THEN 'Concerted Indiscipline'\n        WHEN ctf.code = 'HOSTAGE' THEN 'Hostage'\n        WHEN ctf.code = 'INCIDENT_AT_HEIGHT' THEN 'Incident at Height'\n        WHEN ctf.code = 'DISORDER' THEN 'Disorder'\n        WHEN ctf.code = 'FIND' THEN\n            COALESCE(qa.find_category_new,\n                     CASE\n                         WHEN (qa.found_drug + qa.found_mobile + qa.found_alcohol) > 1 THEN 'Multiple types'\n                         WHEN qa.found_drug = 1 THEN 'Drug / drug equipment'\n                         WHEN qa.found_mobile = 1 THEN 'Mobile phone / mobile related item'\n                         WHEN qa.found_alcohol = 1 THEN 'Alcohol / hooch / distilling equipment'\n                         END\n            )\n        END AS incident_subtype,\n\n    r.status,\n    cs.description AS status_description,\n    r.incident_date_and_time,\n    r.reported_by,\n    INITCAP(pi.first_name) AS first_name,\n    INITCAP(pi.last_name) AS last_name,\n    pi.prisoner_number,\n    cpr.description AS prisoner_role,\n    pi.comment AS prisoner_comment,\n\n    -- Assault Extra Info\n    CASE WHEN ctf.code = 'ASSAULT' THEN COALESCE(qa.is_serious, 'N') END AS serious_injury,\n    CASE WHEN ctf.code = 'ASSAULT' THEN COALESCE(qa.is_concussion, 'N') END AS concussion_treatment,\n    qa.hospital_admission_type,\n    CASE WHEN ctf.code = 'ASSAULT' THEN COALESCE(qa.is_sexual, 'N') END AS sexual_assault,\n    CASE WHEN ctf.code = 'ASSAULT' THEN COALESCE(qa.is_minor, 'N') END AS minor_assault,\n    CASE WHEN ctf.code = 'ASSAULT' THEN COALESCE(qa.is_spitting, 'N') END AS spitting,\n    qa.assault_reason,\n\n    -- Self-Harm Extra Info\n    CASE WHEN ctf.code = 'SELF_HARM' THEN COALESCE(qa.is_cutting, 'N') END AS cutting,\n    CASE WHEN ctf.code = 'SELF_HARM' THEN COALESCE(qa.is_ligature, 'N') END AS strangulation_or_hanging,\n    CASE WHEN ctf.code = 'SELF_HARM' THEN COALESCE(qa.is_burning, 'N') END AS burning,\n\n    -- Finds Extra Info\n    CASE WHEN ctf.code = 'FIND' THEN\n        NULLIF(REGEXP_REPLACE(\n            CASE WHEN COALESCE(qa.f6m_alcohol, 0) = 1 OR COALESCE(qa.found_alcohol, 0) = 1 THEN 'Alcohol, ' ELSE '' END ||\n            CASE WHEN COALESCE(qa.f6m_drugs, 0) = 1 OR COALESCE(qa.found_drug, 0) = 1 THEN 'Drugs, ' ELSE '' END ||\n            CASE WHEN COALESCE(qa.f6m_mobile, 0) = 1 OR COALESCE(qa.found_mobile, 0) = 1 THEN 'Mobile phone, ' ELSE '' END ||\n            CASE WHEN COALESCE(qa.f6m_sim, 0) = 1 THEN 'SIM card, ' ELSE '' END ||\n            CASE WHEN COALESCE(qa.f6m_memory, 0) = 1 THEN 'Memory card, ' ELSE '' END ||\n            CASE WHEN COALESCE(qa.f6m_digital, 0) = 1 THEN 'Digital, ' ELSE '' END ||\n            CASE WHEN COALESCE(qa.f6m_tobacco, 0) = 1 THEN 'Tobacco, ' ELSE '' END ||\n            CASE WHEN COALESCE(qa.f6m_weapon, 0) = 1 THEN 'Weapon, ' ELSE '' END\n        , ',\\\\s*$', ''), '')\n    END AS finds_detail,\n\n    qa.incident_location,\n    -- Incident summary: key facts for the incident type in plain words\n    CASE\n        WHEN ctf.code = 'ASSAULT' THEN\n            NULLIF(REGEXP_REPLACE(\n                CASE WHEN COALESCE(qa.is_serious, 'N') = 'Y' THEN 'Serious injury, ' ELSE '' END ||\n                CASE WHEN COALESCE(qa.is_sexual, 'N') = 'Y' THEN 'Sexual assault, ' ELSE '' END ||\n                CASE WHEN COALESCE(qa.is_minor, 'N') = 'Y' THEN 'Minor assault, ' ELSE '' END ||\n                CASE WHEN COALESCE(qa.is_spitting, 'N') = 'Y' THEN 'Spitting, ' ELSE '' END ||\n                CASE WHEN COALESCE(qa.is_concussion, 'N') = 'Y' THEN 'Concussion treatment, ' ELSE '' END ||\n                CASE WHEN qa.hospital_admission_type IS NOT NULL THEN qa.hospital_admission_type || ', ' ELSE '' END\n            , ',\\\\s*$', ''), '')\n        WHEN ctf.code = 'SELF_HARM' THEN\n            NULLIF(REGEXP_REPLACE(\n                CASE WHEN COALESCE(qa.is_cutting, 'N') = 'Y' THEN 'Cutting, ' ELSE '' END ||\n                CASE WHEN COALESCE(qa.is_ligature, 'N') = 'Y' THEN 'Strangulation or hanging, ' ELSE '' END ||\n                CASE WHEN COALESCE(qa.is_burning, 'N') = 'Y' THEN 'Burning, ' ELSE '' END\n            , ',\\\\s*$', ''), '')\n        WHEN ctf.code = 'FIND' THEN\n            NULLIF(REGEXP_REPLACE(\n                CASE WHEN COALESCE(qa.f6m_alcohol, 0) = 1 OR COALESCE(qa.found_alcohol, 0) = 1 THEN 'Alcohol, ' ELSE '' END ||\n                CASE WHEN COALESCE(qa.f6m_drugs, 0) = 1 OR COALESCE(qa.found_drug, 0) = 1 THEN 'Drugs, ' ELSE '' END ||\n                CASE WHEN COALESCE(qa.f6m_mobile, 0) = 1 OR COALESCE(qa.found_mobile, 0) = 1 THEN 'Mobile phone, ' ELSE '' END ||\n                CASE WHEN COALESCE(qa.f6m_sim, 0) = 1 THEN 'SIM card, ' ELSE '' END ||\n                CASE WHEN COALESCE(qa.f6m_memory, 0) = 1 THEN 'Memory card, ' ELSE '' END ||\n                CASE WHEN COALESCE(qa.f6m_digital, 0) = 1 THEN 'Digital, ' ELSE '' END ||\n                CASE WHEN COALESCE(qa.f6m_tobacco, 0) = 1 THEN 'Tobacco, ' ELSE '' END ||\n                CASE WHEN COALESCE(qa.f6m_weapon, 0) = 1 THEN 'Weapon, ' ELSE '' END\n            , ',\\\\s*$', ''), '')\n    END AS incident_summary\n\nFROM prisons.incidentreporting_prisoner_involvement pi\n         JOIN prisons.incidentreporting_report r ON r.id = pi.report_id\n         JOIN prisons.incidentreporting_constant_status cs ON r.status = cs.code\n         JOIN prisons.incidentreporting_constant_type ct ON r.type = ct.code\n         JOIN prisons.incidentreporting_constant_type_family ctf ON ctf.code = ct.family_code\n         JOIN prisons.incidentreporting_constant_prisoner_role cpr ON cpr.code = pi.prisoner_role\n         JOIN prisons.prisonregister_prison p ON p.prison_id = r.location\n         JOIN prisons.nomis_agency_locations al ON al.agy_loc_id = p.prison_id\n         LEFT JOIN prisons.nomis_areas area ON area.area_class = 'REGION' AND area.area_code = al.noms_region_code\n         LEFT JOIN qa_pivoted qa ON qa.report_id = r.id\n\nWHERE r.status NOT IN ('DUPLICATE', 'NOT_REPORTABLE', 'DRAFT')",
+      "schema": {
+        "field": [
+          {
+            "name": "id",
+            "type": "string"
+          },
+          {
+            "name": "report_reference",
+            "type": "string"
+          },
+          {
+            "name": "type",
+            "type": "string",
+            "filter": {
+              "type": "multiselect",
+              "dynamicoptions": {
+                "maximumOptions": 60,
+                "returnAsStaticOptions": true,
+                "dataset": "types",
+                "name": "code",
+                "display": "description"
+              }
+            }
+          },
+          {
+            "name": "type_description",
+            "type": "string"
+          },
+          {
+            "name": "status",
+            "type": "string",
+            "filter": {
+              "type": "multiselect",
+              "interactive": true,
+              "dynamicoptions": {
+                "maximumOptions": 20,
+                "returnAsStaticOptions": true,
+                "dataset": "status",
+                "name": "code",
+                "display": "description"
+              }
+            }
+          },
+          {
+            "name": "status_description",
+            "type": "string"
+          },
+          {
+            "name": "incident_date_and_time",
+            "type": "datetime"
+          },
+          {
+            "name": "reported_by",
+            "type": "string"
+          },
+          {
+            "name": "first_name",
+            "type": "string"
+          },
+          {
+            "name": "last_name",
+            "type": "string"
+          },
+          {
+            "name": "prisoner_number",
+            "type": "string"
+          },
+          {
+            "name": "prisoner_role",
+            "type": "string"
+          },
+          {
+            "name": "prisoner_comment",
+            "type": "string"
+          },
+          {
+            "name": "location",
+            "type": "string"
+          },
+          {
+            "name": "location_name",
+            "type": "string"
+          },
+          {
+            "name": "region_code",
+            "type": "string"
+          },
+          {
+            "name": "region_name",
+            "type": "string"
+          },
+          {
+            "name": "incident_subtype",
+            "type": "string"
+          },
+          {
+            "name": "serious_injury",
+            "type": "string"
+          },
+          {
+            "name": "concussion_treatment",
+            "type": "string"
+          },
+          {
+            "name": "hospital_admission_type",
+            "type": "string"
+          },
+          {
+            "name": "sexual_assault",
+            "type": "string"
+          },
+          {
+            "name": "minor_assault",
+            "type": "string"
+          },
+          {
+            "name": "spitting",
+            "type": "string"
+          },
+          {
+            "name": "assault_reason",
+            "type": "string"
+          },
+          {
+            "name": "cutting",
+            "type": "string"
+          },
+          {
+            "name": "strangulation_or_hanging",
+            "type": "string"
+          },
+          {
+            "name": "burning",
+            "type": "string"
+          },
+          {
+            "name": "finds_detail",
+            "type": "string"
+          },
+          {
+            "name": "incident_location",
+            "type": "string"
+          },
+          {
+            "name": "incident_summary",
             "type": "string"
           }
         ]
@@ -2128,6 +2284,387 @@
             "defaultsort": true,
             "sortdirection": "desc",
             "formula": "make_url('https://incident-reporting-${env}.hmpps.service.justice.gov.uk/reports?searchID=${prisoner_number}',${total_incidents},TRUE)"
+          }
+        ]
+      },
+      "destination": []
+    },
+    {
+      "id": "prisoner-incident-detail",
+      "name": "Prisoner Involvement in Incidents: Establishment Level",
+      "description": "Shows each prisoner involved in a reported incident alongside their role, any comments recorded against them, and the where the incident took place. For key incident types, structured Q&A detail is surfaced as additional columns: assault severity flags (serious, sexual, minor, spitting, concussion treatment, hospital admission, and reason); self-harm method flags (cutting, strangulation/hanging, burning); and for finds, a comma-separated list of items identified.",
+      "version": "1.0.0",
+      "dataset": "$ref:prisoner-incident-detail",
+      "render": "HTML",
+      "feature": [
+        {
+          "type": "print"
+        }
+      ],
+      "metadata": {
+        "hints": [
+          "interactive"
+        ]
+      },
+      "specification": {
+        "template": "list",
+        "field": [
+          {
+            "name": "$ref:prisoner_number",
+            "display": "Prisoner number",
+            "sortable": true,
+            "formula": "make_url('https://prisoner-${env}.digital.prison.service.justice.gov.uk/prisoner/${prisoner_number}',${prisoner_number},TRUE)",
+            "visible": "true",
+            "defaultsort": false,
+            "filter": {
+              "type": "text"
+            }
+          },
+          {
+            "name": "$ref:last_name",
+            "formula": "${last_name}, ${first_name}",
+            "display": "Name",
+            "sortable": true,
+            "visible": "true",
+            "defaultsort": false
+          },
+          {
+            "name": "$ref:report_reference",
+            "display": "Incident number",
+            "sortable": true,
+            "formula": "make_url('https://incident-reporting-${env}.hmpps.service.justice.gov.uk/reports/${id}',${report_reference},TRUE)",
+            "visible": "true",
+            "defaultsort": false
+          },
+          {
+            "name": "$ref:incident_date_and_time",
+            "display": "Date of incident",
+            "formula": "format_date(${incident_date_and_time}, 'dd/MM/yyyy HH:mm')",
+            "sortable": true,
+            "visible": "true",
+            "defaultsort": true,
+            "sortdirection": "desc",
+            "filter": {
+              "type": "daterange",
+              "default": "today(-1,months) - today()"
+            }
+          },
+          {
+            "name": "$ref:type",
+            "display": "Type code",
+            "sortable": true,
+            "visible": "false",
+            "defaultsort": false
+          },
+          {
+            "name": "$ref:type_description",
+            "display": "Incident type",
+            "sortable": true,
+            "visible": "true",
+            "defaultsort": false
+          },
+          {
+            "name": "$ref:status",
+            "display": "Status code",
+            "sortable": false,
+            "visible": "false",
+            "defaultsort": false
+          },
+          {
+            "name": "$ref:status_description",
+            "display": "Incident status",
+            "sortable": true,
+            "visible": "true",
+            "defaultsort": false
+          },
+          {
+            "name": "$ref:location",
+            "display": "Location",
+            "sortable": true,
+            "visible": "false",
+            "defaultsort": false,
+            "filter": {
+              "type": "multiselect",
+              "mandatory": false,
+              "dynamicoptions": {
+                "maximumOptions": 140,
+                "returnAsStaticOptions": true,
+                "dataset": "prisons",
+                "name": "prison_id",
+                "display": "prison_name"
+              }
+            }
+          },
+          {
+            "name": "$ref:location_name",
+            "display": "Location name",
+            "sortable": true,
+            "visible": "true",
+            "defaultsort": false
+          },
+          {
+            "name": "$ref:incident_subtype",
+            "display": "Subtype",
+            "sortable": true,
+            "visible": "true",
+            "defaultsort": false,
+            "filter": {
+              "type": "multiselect",
+              "mandatory": false,
+              "staticoptions": [
+                {
+                  "name": "Prisoner on prisoner (PoP)",
+                  "display": "Prisoner on prisoner (PoP)"
+                },
+                {
+                  "name": "Prisoner on staff (PoS)",
+                  "display": "Prisoner on staff (PoS)"
+                },
+                {
+                  "name": "Prisoner on other",
+                  "display": "Prisoner on other"
+                },
+                {
+                  "name": "Other",
+                  "display": "Other"
+                }
+              ]
+            }
+          },
+          {
+            "name": "$ref:region_code",
+            "display": "Region",
+            "sortable": true,
+            "visible": "false",
+            "defaultsort": false,
+            "filter": {
+              "type": "multiselect",
+              "mandatory": false,
+              "dynamicoptions": {
+                "maximumOptions": 20,
+                "returnAsStaticOptions": true,
+                "dataset": "regionCodes",
+                "name": "code",
+                "display": "description"
+              }
+            }
+          },
+          {
+            "name": "$ref:region_name",
+            "display": "Region name",
+            "sortable": true,
+            "visible": "false",
+            "defaultsort": false
+          },
+          {
+            "name": "$ref:prisoner_role",
+            "display": "Prisoner role",
+            "sortable": false,
+            "visible": "true",
+            "defaultsort": false,
+            "filter": {
+              "type": "multiselect",
+              "mandatory": false,
+              "dynamicoptions": {
+                "maximumOptions": 20,
+                "returnAsStaticOptions": true,
+                "dataset": "prisoner_role",
+                "name": "description",
+                "display": "description"
+              }
+            }
+          },
+          {
+            "name": "$ref:incident_location",
+            "display": "Incident location",
+            "sortable": false,
+            "visible": "true",
+            "defaultsort": false
+          },
+          {
+            "name": "$ref:incident_summary",
+            "display": "Incident summary",
+            "sortable": false,
+            "visible": "true",
+            "defaultsort": false
+          },
+          {
+            "name": "$ref:prisoner_comment",
+            "display": "Prisoner comment",
+            "sortable": false,
+            "visible": "true",
+            "defaultsort": false
+          },
+          {
+            "name": "$ref:assault_reason",
+            "display": "Assault reason",
+            "sortable": false,
+            "visible": "true"
+          },
+          {
+            "name": "$ref:serious_injury",
+            "display": "Serious injury",
+            "sortable": false,
+            "visible": "false",
+            "filter": {
+              "type": "radio",
+              "staticoptions": [
+                {
+                  "name": "Y",
+                  "display": "Serious injury"
+                },
+                {
+                  "name": "N",
+                  "display": "Non serious injury"
+                }
+              ]
+            }
+          },
+          {
+            "name": "$ref:concussion_treatment",
+            "display": "Concussion treatment",
+            "sortable": false,
+            "visible": "false",
+            "filter": {
+              "type": "radio",
+              "staticoptions": [
+                {
+                  "name": "Y",
+                  "display": "Concussion"
+                },
+                {
+                  "name": "N",
+                  "display": "No concussion"
+                }
+              ]
+            }
+          },
+          {
+            "name": "$ref:hospital_admission_type",
+            "display": "Hospital admission type",
+            "sortable": false,
+            "visible": "true"
+          },
+          {
+            "name": "$ref:sexual_assault",
+            "display": "Sexual assault",
+            "sortable": false,
+            "visible": "false",
+            "filter": {
+              "type": "radio",
+              "staticoptions": [
+                {
+                  "name": "Y",
+                  "display": "Sexual assault"
+                },
+                {
+                  "name": "N",
+                  "display": "Non-sexual assault"
+                }
+              ]
+            }
+          },
+          {
+            "name": "$ref:minor_assault",
+            "display": "Minor assault",
+            "sortable": false,
+            "visible": "false",
+            "filter": {
+              "type": "radio",
+              "staticoptions": [
+                {
+                  "name": "Y",
+                  "display": "Minor assault"
+                },
+                {
+                  "name": "N",
+                  "display": "Not a minor assault"
+                }
+              ]
+            }
+          },
+          {
+            "name": "$ref:spitting",
+            "display": "Spitting",
+            "sortable": false,
+            "visible": "false",
+            "filter": {
+              "type": "radio",
+              "staticoptions": [
+                {
+                  "name": "Y",
+                  "display": "Spitting involved"
+                },
+                {
+                  "name": "N",
+                  "display": "Spitting not involved"
+                }
+              ]
+            }
+          },
+          {
+            "name": "$ref:cutting",
+            "display": "Cutting",
+            "sortable": false,
+            "visible": "false",
+            "filter": {
+              "type": "radio",
+              "staticoptions": [
+                {
+                  "name": "Y",
+                  "display": "Cutting involved"
+                },
+                {
+                  "name": "N",
+                  "display": "Cutting not involved"
+                }
+              ]
+            }
+          },
+          {
+            "name": "$ref:strangulation_or_hanging",
+            "display": "Strangulation or hanging",
+            "sortable": false,
+            "visible": "false",
+            "filter": {
+              "type": "radio",
+              "staticoptions": [
+                {
+                  "name": "Y",
+                  "display": "Strangulation or hanging involved"
+                },
+                {
+                  "name": "N",
+                  "display": "No strangulation or hanging involved"
+                }
+              ]
+            }
+          },
+          {
+            "name": "$ref:burning",
+            "display": "Burning",
+            "sortable": false,
+            "visible": "false",
+            "filter": {
+              "type": "radio",
+              "staticoptions": [
+                {
+                  "name": "Y",
+                  "display": "Burning involved"
+                },
+                {
+                  "name": "N",
+                  "display": "No burning involved"
+                }
+              ]
+            }
+          },
+          {
+            "name": "$ref:finds_detail",
+            "display": "Finds detail",
+            "sortable": false,
+            "visible": "true",
+            "defaultsort": false
           }
         ]
       },


### PR DESCRIPTION
## Summary

Adds a new `prisoner-incident-detail` report variant to the Incident Reporting Data Product Definition (`incident-report.json`), deployed across all environments (dev / test / preprod / prod). The report surfaces each prisoner's involvement in an incident alongside structured Q&A-derived detail — assault flags, self-harm method, found items for finds, the location where the incident took place, and a plain-English summary of key facts.

---

## New report: Prisoner Involvement in Incidents: Establishment Level

**Dataset ID:** `prisoner-incident-detail`

### What it does

One row per prisoner per incident (filtered to exclude DUPLICATE, NOT_REPORTABLE and DRAFT statuses). Joins the prisoner involvement table to the report, type, status, prison and region tables and — via a single-pass CTE pivot over the Q&A tables — unpacks incident-type-specific answers into dedicated columns without repeated scans of the response tables.

### Columns

| Column | Description |
|---|---|
| `prisoner_number` | NOMIS prisoner number |
| `last_name` / `first_name` | INITCAP-formatted name |
| `report_reference` | Incident number (linked to IRS UI) |
| `incident_date_and_time` | Date and time of incident |
| `type_description` | Human-readable incident type |
| `status_description` | Human-readable status |
| `location_name` | Prison name |
| `region_name` | NOMIS region |
| `incident_subtype` | Derived subtype label (e.g. assault PoP/PoS, find category) |
| `prisoner_role` | Role in the incident (assailant, victim, witness, etc.) |
| `incident_location` | Where the incident took place, with free-text comment appended in parentheses where recorded (e.g. `Wing (B Wing, Cell 23)`) |
| `incident_summary` | Plain-English summary of key type-specific facts (see below) |
| `prisoner_comment` | Any comment recorded against the prisoner's involvement |
| **Assault columns** | |
| `serious_injury` | Y/N — serious injury recorded |
| `concussion_treatment` | Y/N — concussion treatment required |
| `hospital_admission_type` | Admission category if hospitalised (A&E, inpatient, life support) |
| `sexual_assault` | Y/N |
| `minor_assault` | Y/N |
| `spitting` | Y/N |
| `assault_reason` | Free-text reason recorded against the incident |
| **Self-harm columns** | |
| `cutting` | Y/N |
| `strangulation_or_hanging` | Y/N |
| `burning` | Y/N |
| **Finds column** | |
| `finds_detail` | Comma-separated list of item types found (e.g. `Drugs, Mobile phone, SIM card`) |

### `incident_summary` column

A computed plain-English field that aggregates the most important flags for the incident type into a single readable value, intended as a quick visual cue:

- **Assault** — lists whichever of the following apply: `Serious injury`, `Sexual assault`, `Minor assault`, `Spitting`, `Concussion treatment`, plus the hospital admission type if recorded. Example: `Serious injury, Concussion treatment, Inpatient (overnight)`
- **Self-harm** — lists whichever method flags are Y: `Cutting`, `Strangulation or hanging`, `Burning`. Example: `Cutting`
- **Finds** — identical to `finds_detail`. Example: `Drugs, Mobile phone, SIM card`
- All other types — NULL

### `incident_location` column

Derived from Q&A responses across all active and legacy incident types via a single `MAX(CASE WHEN q.code IN (...))` CTE column. Covers:

| Active types | Legacy / inactive types |
|---|---|
| ASSAULT_5, SELF_HARM_1, FIND_6 | ASSAULT_1 |
| DISORDER_2, FIRE_1, DIRTY_PROTEST_1 | DISORDER_1, BARRICADE_1, HOSTAGE_1 |
| DEATH_PRISONER_1, DEATH_OTHER_1 | CONCERTED_INDISCIPLINE_1 |
| ABSCOND_1, BREACH_OF_SECURITY_1 | INCIDENT_AT_HEIGHT_1 |
| ESCAPE_FROM_ESCORT_1, ESCAPE_FROM_PRISON_1 | |
| ATTEMPTED_ESCAPE_FROM_ESCORT_1, ATTEMPTED_ESCAPE_FROM_PRISON_1 | |
| BOMB_1, RELEASE_IN_ERROR_1 | |

Where the Q&A flow records a mandatory free-text comment (e.g. Cell, Wing, Association area), it is appended in parentheses after the location label.

### SQL approach

The dataset uses a **CTE pivot** (`qa_pivoted`) that scans `incidentreporting_question` and `incidentreporting_response` once per report, aggregating all required Q&A answers into a single row using `MAX(CASE WHEN q.code = '...' THEN ... END)`. The main SELECT left-joins this CTE onto the prisoner involvement table. This avoids repeated Q&A table scans and keeps the query performant across large incident datasets.

---

## Files changed

```
dpd/dev/definitions/prisons/orphanage/incident-report.json
dpd/test/definitions/prisons/orphanage/incident-report.json
dpd/preprod/definitions/prisons/orphanage/incident-report.json
dpd/prod/definitions/prisons/orphanage/incident-report.json
```

## Validation

- `npm run validate` — passes (schema compliance across all environments)
- `npm run uniqueness` — passes (no duplicate report variant IDs)
