### PR TITLE
Update dpds that use ts to type 'timestamp'

### DIFF
--- a/dpd/dev/definitions/prisons/orphanage/act-appointment-by-caseload.json
+++ b/dpd/dev/definitions/prisons/orphanage/act-appointment-by-caseload.json
@@ -431,7 +431,7 @@
                   {
                     "id": "$ref:ts",
                     "display": "Date",
-                    "type": "date"
+                    "type": "timestamp"
                   },
                   {
                     "id": "$ref:prison_code",
@@ -442,7 +442,7 @@
                   {
                     "id": "$ref:ts",
                     "display": "Date",
-                    "type": "date"
+                    "type": "timestamp"
                   },
                   {
                     "id": "$ref:appointment_count",
@@ -513,7 +513,7 @@
                   {
                     "id": "$ref:ts",
                     "display": "Date",
-                    "type": "date"
+                    "type": "timestamp"
                   },
                   {
                     "id": "$ref:appointments",
@@ -538,7 +538,7 @@
                   {
                     "id": "$ref:ts",
                     "display": "Date",
-                    "type": "date"
+                    "type": "timestamp"
                   },
                   {
                     "id": "$ref:attendees",
@@ -563,7 +563,7 @@
                   {
                     "id": "$ref:ts",
                     "display": "Date",
-                    "type": "date"
+                    "type": "timestamp"
                   },
                   {
                     "id": "$ref:attended_pct",
@@ -588,7 +588,7 @@
                   {
                     "id": "$ref:ts",
                     "display": "Date",
-                    "type": "date"
+                    "type": "timestamp"
                   },
                   {
                     "id": "$ref:non_attended_pct",
@@ -613,7 +613,7 @@
                   {
                     "id": "$ref:ts",
                     "display": "Date",
-                    "type": "date"
+                    "type": "timestamp"
                   },
                   {
                     "id": "$ref:not_recorded_pct",
@@ -638,7 +638,7 @@
                   {
                     "id": "$ref:ts",
                     "display": "Date",
-                    "type": "date"
+                    "type": "timestamp"
                   },
                   {
                     "id": "$ref:tier1_pct",
@@ -663,7 +663,7 @@
                   {
                     "id": "$ref:ts",
                     "display": "Date",
-                    "type": "date"
+                    "type": "timestamp"
                   },
                   {
                     "id": "$ref:tier2_pct",
@@ -688,7 +688,7 @@
                   {
                     "id": "$ref:ts",
                     "display": "Date",
-                    "type": "date"
+                    "type": "timestamp"
                   },
                   {
                     "id": "$ref:cancellations",

--- a/dpd/dev/definitions/prisons/orphanage/act-appointment-by-caseload.json
+++ b/dpd/dev/definitions/prisons/orphanage/act-appointment-by-caseload.json
@@ -142,7 +142,7 @@
         "field": [
           {
             "name": "ts",
-            "type": "date",
+            "type": "timestamp",
             "display": "Date",
             "formula": "format_date(${ts}, 'dd MMMM yyyy')",
             "filter": {
@@ -430,8 +430,7 @@
                 "key": [
                   {
                     "id": "$ref:ts",
-                    "display": "Date",
-                    "type": "timestamp"
+                    "display": "Date"
                   },
                   {
                     "id": "$ref:prison_code",
@@ -441,8 +440,7 @@
                 "measure": [
                   {
                     "id": "$ref:ts",
-                    "display": "Date",
-                    "type": "timestamp"
+                    "display": "Date"
                   },
                   {
                     "id": "$ref:appointment_count",
@@ -512,8 +510,7 @@
                 "measure": [
                   {
                     "id": "$ref:ts",
-                    "display": "Date",
-                    "type": "timestamp"
+                    "display": "Date"
                   },
                   {
                     "id": "$ref:appointments",
@@ -537,8 +534,7 @@
                 "measure": [
                   {
                     "id": "$ref:ts",
-                    "display": "Date",
-                    "type": "timestamp"
+                    "display": "Date"
                   },
                   {
                     "id": "$ref:attendees",
@@ -562,8 +558,7 @@
                 "measure": [
                   {
                     "id": "$ref:ts",
-                    "display": "Date",
-                    "type": "timestamp"
+                    "display": "Date"
                   },
                   {
                     "id": "$ref:attended_pct",
@@ -587,8 +582,7 @@
                 "measure": [
                   {
                     "id": "$ref:ts",
-                    "display": "Date",
-                    "type": "timestamp"
+                    "display": "Date"
                   },
                   {
                     "id": "$ref:non_attended_pct",
@@ -612,8 +606,7 @@
                 "measure": [
                   {
                     "id": "$ref:ts",
-                    "display": "Date",
-                    "type": "timestamp"
+                    "display": "Date"
                   },
                   {
                     "id": "$ref:not_recorded_pct",
@@ -637,8 +630,7 @@
                 "measure": [
                   {
                     "id": "$ref:ts",
-                    "display": "Date",
-                    "type": "timestamp"
+                    "display": "Date"
                   },
                   {
                     "id": "$ref:tier1_pct",
@@ -662,8 +654,7 @@
                 "measure": [
                   {
                     "id": "$ref:ts",
-                    "display": "Date",
-                    "type": "timestamp"
+                    "display": "Date"
                   },
                   {
                     "id": "$ref:tier2_pct",
@@ -687,8 +678,7 @@
                 "measure": [
                   {
                     "id": "$ref:ts",
-                    "display": "Date",
-                    "type": "timestamp"
+                    "display": "Date"
                   },
                   {
                     "id": "$ref:cancellations",

--- a/dpd/dev/definitions/prisons/orphanage/act-appointment-by-caseload.json
+++ b/dpd/dev/definitions/prisons/orphanage/act-appointment-by-caseload.json
@@ -430,7 +430,8 @@
                 "key": [
                   {
                     "id": "$ref:ts",
-                    "display": "Date"
+                    "display": "Date",
+                    "type": "date"
                   },
                   {
                     "id": "$ref:prison_code",
@@ -440,7 +441,8 @@
                 "measure": [
                   {
                     "id": "$ref:ts",
-                    "display": "Date"
+                    "display": "Date",
+                    "type": "date"
                   },
                   {
                     "id": "$ref:appointment_count",
@@ -510,7 +512,8 @@
                 "measure": [
                   {
                     "id": "$ref:ts",
-                    "display": "Date"
+                    "display": "Date",
+                    "type": "date"
                   },
                   {
                     "id": "$ref:appointments",
@@ -534,7 +537,8 @@
                 "measure": [
                   {
                     "id": "$ref:ts",
-                    "display": "Date"
+                    "display": "Date",
+                    "type": "date"
                   },
                   {
                     "id": "$ref:attendees",
@@ -558,7 +562,8 @@
                 "measure": [
                   {
                     "id": "$ref:ts",
-                    "display": "Date"
+                    "display": "Date",
+                    "type": "date"
                   },
                   {
                     "id": "$ref:attended_pct",
@@ -582,7 +587,8 @@
                 "measure": [
                   {
                     "id": "$ref:ts",
-                    "display": "Date"
+                    "display": "Date",
+                    "type": "date"
                   },
                   {
                     "id": "$ref:non_attended_pct",
@@ -606,7 +612,8 @@
                 "measure": [
                   {
                     "id": "$ref:ts",
-                    "display": "Date"
+                    "display": "Date",
+                    "type": "date"
                   },
                   {
                     "id": "$ref:not_recorded_pct",
@@ -630,7 +637,8 @@
                 "measure": [
                   {
                     "id": "$ref:ts",
-                    "display": "Date"
+                    "display": "Date",
+                    "type": "date"
                   },
                   {
                     "id": "$ref:tier1_pct",
@@ -654,7 +662,8 @@
                 "measure": [
                   {
                     "id": "$ref:ts",
-                    "display": "Date"
+                    "display": "Date",
+                    "type": "date"
                   },
                   {
                     "id": "$ref:tier2_pct",
@@ -678,7 +687,8 @@
                 "measure": [
                   {
                     "id": "$ref:ts",
-                    "display": "Date"
+                    "display": "Date",
+                    "type": "date"
                   },
                   {
                     "id": "$ref:cancellations",

--- a/dpd/preprod/definitions/prisons/orphanage/act-appointment-by-caseload.json
+++ b/dpd/preprod/definitions/prisons/orphanage/act-appointment-by-caseload.json
@@ -431,7 +431,7 @@
                   {
                     "id": "$ref:ts",
                     "display": "Date",
-                    "type": "date"
+                    "type": "timestamp"
                   },
                   {
                     "id": "$ref:prison_code",
@@ -442,7 +442,7 @@
                   {
                     "id": "$ref:ts",
                     "display": "Date",
-                    "type": "date"
+                    "type": "timestamp"
                   },
                   {
                     "id": "$ref:appointment_count",
@@ -513,7 +513,7 @@
                   {
                     "id": "$ref:ts",
                     "display": "Date",
-                    "type": "date"
+                    "type": "timestamp"
                   },
                   {
                     "id": "$ref:appointments",
@@ -538,7 +538,7 @@
                   {
                     "id": "$ref:ts",
                     "display": "Date",
-                    "type": "date"
+                    "type": "timestamp"
                   },
                   {
                     "id": "$ref:attendees",
@@ -563,7 +563,7 @@
                   {
                     "id": "$ref:ts",
                     "display": "Date",
-                    "type": "date"
+                    "type": "timestamp"
                   },
                   {
                     "id": "$ref:attended_pct",
@@ -588,7 +588,7 @@
                   {
                     "id": "$ref:ts",
                     "display": "Date",
-                    "type": "date"
+                    "type": "timestamp"
                   },
                   {
                     "id": "$ref:non_attended_pct",
@@ -613,7 +613,7 @@
                   {
                     "id": "$ref:ts",
                     "display": "Date",
-                    "type": "date"
+                    "type": "timestamp"
                   },
                   {
                     "id": "$ref:not_recorded_pct",
@@ -638,7 +638,7 @@
                   {
                     "id": "$ref:ts",
                     "display": "Date",
-                    "type": "date"
+                    "type": "timestamp"
                   },
                   {
                     "id": "$ref:tier1_pct",
@@ -663,7 +663,7 @@
                   {
                     "id": "$ref:ts",
                     "display": "Date",
-                    "type": "date"
+                    "type": "timestamp"
                   },
                   {
                     "id": "$ref:tier2_pct",
@@ -688,7 +688,7 @@
                   {
                     "id": "$ref:ts",
                     "display": "Date",
-                    "type": "date"
+                    "type": "timestamp"
                   },
                   {
                     "id": "$ref:cancellations",

--- a/dpd/preprod/definitions/prisons/orphanage/act-appointment-by-caseload.json
+++ b/dpd/preprod/definitions/prisons/orphanage/act-appointment-by-caseload.json
@@ -142,7 +142,7 @@
         "field": [
           {
             "name": "ts",
-            "type": "date",
+            "type": "timestamp",
             "display": "Date",
             "formula": "format_date(${ts}, 'dd MMMM yyyy')",
             "filter": {
@@ -430,8 +430,7 @@
                 "key": [
                   {
                     "id": "$ref:ts",
-                    "display": "Date",
-                    "type": "timestamp"
+                    "display": "Date"
                   },
                   {
                     "id": "$ref:prison_code",
@@ -441,8 +440,7 @@
                 "measure": [
                   {
                     "id": "$ref:ts",
-                    "display": "Date",
-                    "type": "timestamp"
+                    "display": "Date"
                   },
                   {
                     "id": "$ref:appointment_count",
@@ -512,8 +510,7 @@
                 "measure": [
                   {
                     "id": "$ref:ts",
-                    "display": "Date",
-                    "type": "timestamp"
+                    "display": "Date"
                   },
                   {
                     "id": "$ref:appointments",
@@ -537,8 +534,7 @@
                 "measure": [
                   {
                     "id": "$ref:ts",
-                    "display": "Date",
-                    "type": "timestamp"
+                    "display": "Date"
                   },
                   {
                     "id": "$ref:attendees",
@@ -562,8 +558,7 @@
                 "measure": [
                   {
                     "id": "$ref:ts",
-                    "display": "Date",
-                    "type": "timestamp"
+                    "display": "Date"
                   },
                   {
                     "id": "$ref:attended_pct",
@@ -587,8 +582,7 @@
                 "measure": [
                   {
                     "id": "$ref:ts",
-                    "display": "Date",
-                    "type": "timestamp"
+                    "display": "Date"
                   },
                   {
                     "id": "$ref:non_attended_pct",
@@ -612,8 +606,7 @@
                 "measure": [
                   {
                     "id": "$ref:ts",
-                    "display": "Date",
-                    "type": "timestamp"
+                    "display": "Date"
                   },
                   {
                     "id": "$ref:not_recorded_pct",
@@ -637,8 +630,7 @@
                 "measure": [
                   {
                     "id": "$ref:ts",
-                    "display": "Date",
-                    "type": "timestamp"
+                    "display": "Date"
                   },
                   {
                     "id": "$ref:tier1_pct",
@@ -662,8 +654,7 @@
                 "measure": [
                   {
                     "id": "$ref:ts",
-                    "display": "Date",
-                    "type": "timestamp"
+                    "display": "Date"
                   },
                   {
                     "id": "$ref:tier2_pct",
@@ -687,8 +678,7 @@
                 "measure": [
                   {
                     "id": "$ref:ts",
-                    "display": "Date",
-                    "type": "timestamp"
+                    "display": "Date"
                   },
                   {
                     "id": "$ref:cancellations",

--- a/dpd/preprod/definitions/prisons/orphanage/act-appointment-by-caseload.json
+++ b/dpd/preprod/definitions/prisons/orphanage/act-appointment-by-caseload.json
@@ -430,7 +430,8 @@
                 "key": [
                   {
                     "id": "$ref:ts",
-                    "display": "Date"
+                    "display": "Date",
+                    "type": "date"
                   },
                   {
                     "id": "$ref:prison_code",
@@ -440,7 +441,8 @@
                 "measure": [
                   {
                     "id": "$ref:ts",
-                    "display": "Date"
+                    "display": "Date",
+                    "type": "date"
                   },
                   {
                     "id": "$ref:appointment_count",
@@ -510,7 +512,8 @@
                 "measure": [
                   {
                     "id": "$ref:ts",
-                    "display": "Date"
+                    "display": "Date",
+                    "type": "date"
                   },
                   {
                     "id": "$ref:appointments",
@@ -534,7 +537,8 @@
                 "measure": [
                   {
                     "id": "$ref:ts",
-                    "display": "Date"
+                    "display": "Date",
+                    "type": "date"
                   },
                   {
                     "id": "$ref:attendees",
@@ -558,7 +562,8 @@
                 "measure": [
                   {
                     "id": "$ref:ts",
-                    "display": "Date"
+                    "display": "Date",
+                    "type": "date"
                   },
                   {
                     "id": "$ref:attended_pct",
@@ -582,7 +587,8 @@
                 "measure": [
                   {
                     "id": "$ref:ts",
-                    "display": "Date"
+                    "display": "Date",
+                    "type": "date"
                   },
                   {
                     "id": "$ref:non_attended_pct",
@@ -606,7 +612,8 @@
                 "measure": [
                   {
                     "id": "$ref:ts",
-                    "display": "Date"
+                    "display": "Date",
+                    "type": "date"
                   },
                   {
                     "id": "$ref:not_recorded_pct",
@@ -630,7 +637,8 @@
                 "measure": [
                   {
                     "id": "$ref:ts",
-                    "display": "Date"
+                    "display": "Date",
+                    "type": "date"
                   },
                   {
                     "id": "$ref:tier1_pct",
@@ -654,7 +662,8 @@
                 "measure": [
                   {
                     "id": "$ref:ts",
-                    "display": "Date"
+                    "display": "Date",
+                    "type": "date"
                   },
                   {
                     "id": "$ref:tier2_pct",
@@ -678,7 +687,8 @@
                 "measure": [
                   {
                     "id": "$ref:ts",
-                    "display": "Date"
+                    "display": "Date",
+                    "type": "date"
                   },
                   {
                     "id": "$ref:cancellations",

--- a/dpd/prod/definitions/prisons/orphanage/act-appointment-by-caseload.json
+++ b/dpd/prod/definitions/prisons/orphanage/act-appointment-by-caseload.json
@@ -423,7 +423,7 @@
                   {
                     "id": "$ref:ts",
                     "display": "Date",
-                    "type": "date"
+                    "type": "timestamp"
                   },
                   {
                     "id": "$ref:prison_code",
@@ -434,7 +434,7 @@
                   {
                     "id": "$ref:ts",
                     "display": "Date",
-                    "type": "date"
+                    "type": "timestamp"
                   },
                   {
                     "id": "$ref:appointment_count",
@@ -505,7 +505,7 @@
                   {
                     "id": "$ref:ts",
                     "display": "Date",
-                    "type": "date"
+                    "type": "timestamp"
                   },
                   {
                     "id": "$ref:appointments",
@@ -530,7 +530,7 @@
                   {
                     "id": "$ref:ts",
                     "display": "Date",
-                    "type": "date"
+                    "type": "timestamp"
                   },
                   {
                     "id": "$ref:attendees",
@@ -555,7 +555,7 @@
                   {
                     "id": "$ref:ts",
                     "display": "Date",
-                    "type": "date"
+                    "type": "timestamp"
                   },
                   {
                     "id": "$ref:attended_pct",
@@ -580,7 +580,7 @@
                   {
                     "id": "$ref:ts",
                     "display": "Date",
-                    "type": "date"
+                    "type": "timestamp"
                   },
                   {
                     "id": "$ref:non_attended_pct",
@@ -605,7 +605,7 @@
                   {
                     "id": "$ref:ts",
                     "display": "Date",
-                    "type": "date"
+                    "type": "timestamp"
                   },
                   {
                     "id": "$ref:not_recorded_pct",
@@ -630,7 +630,7 @@
                   {
                     "id": "$ref:ts",
                     "display": "Date",
-                    "type": "date"
+                    "type": "timestamp"
                   },
                   {
                     "id": "$ref:tier1_pct",
@@ -655,7 +655,7 @@
                   {
                     "id": "$ref:ts",
                     "display": "Date",
-                    "type": "date"
+                    "type": "timestamp"
                   },
                   {
                     "id": "$ref:tier2_pct",
@@ -680,7 +680,7 @@
                   {
                     "id": "$ref:ts",
                     "display": "Date",
-                    "type": "date"
+                    "type": "timestamp"
                   },
                   {
                     "id": "$ref:cancellations",

--- a/dpd/prod/definitions/prisons/orphanage/act-appointment-by-caseload.json
+++ b/dpd/prod/definitions/prisons/orphanage/act-appointment-by-caseload.json
@@ -422,7 +422,8 @@
                 "key": [
                   {
                     "id": "$ref:ts",
-                    "display": "Date"
+                    "display": "Date",
+                    "type": "date"
                   },
                   {
                     "id": "$ref:prison_code",
@@ -432,7 +433,8 @@
                 "measure": [
                   {
                     "id": "$ref:ts",
-                    "display": "Date"
+                    "display": "Date",
+                    "type": "date"
                   },
                   {
                     "id": "$ref:appointment_count",
@@ -502,7 +504,8 @@
                 "measure": [
                   {
                     "id": "$ref:ts",
-                    "display": "Date"
+                    "display": "Date",
+                    "type": "date"
                   },
                   {
                     "id": "$ref:appointments",
@@ -526,7 +529,8 @@
                 "measure": [
                   {
                     "id": "$ref:ts",
-                    "display": "Date"
+                    "display": "Date",
+                    "type": "date"
                   },
                   {
                     "id": "$ref:attendees",
@@ -550,7 +554,8 @@
                 "measure": [
                   {
                     "id": "$ref:ts",
-                    "display": "Date"
+                    "display": "Date",
+                    "type": "date"
                   },
                   {
                     "id": "$ref:attended_pct",
@@ -574,7 +579,8 @@
                 "measure": [
                   {
                     "id": "$ref:ts",
-                    "display": "Date"
+                    "display": "Date",
+                    "type": "date"
                   },
                   {
                     "id": "$ref:non_attended_pct",
@@ -598,7 +604,8 @@
                 "measure": [
                   {
                     "id": "$ref:ts",
-                    "display": "Date"
+                    "display": "Date",
+                    "type": "date"
                   },
                   {
                     "id": "$ref:not_recorded_pct",
@@ -622,7 +629,8 @@
                 "measure": [
                   {
                     "id": "$ref:ts",
-                    "display": "Date"
+                    "display": "Date",
+                    "type": "date"
                   },
                   {
                     "id": "$ref:tier1_pct",
@@ -646,7 +654,8 @@
                 "measure": [
                   {
                     "id": "$ref:ts",
-                    "display": "Date"
+                    "display": "Date",
+                    "type": "date"
                   },
                   {
                     "id": "$ref:tier2_pct",
@@ -670,7 +679,8 @@
                 "measure": [
                   {
                     "id": "$ref:ts",
-                    "display": "Date"
+                    "display": "Date",
+                    "type": "date"
                   },
                   {
                     "id": "$ref:cancellations",

--- a/dpd/prod/definitions/prisons/orphanage/act-appointment-by-caseload.json
+++ b/dpd/prod/definitions/prisons/orphanage/act-appointment-by-caseload.json
@@ -134,7 +134,7 @@
         "field": [
           {
             "name": "ts",
-            "type": "date",
+            "type": "timestamp",
             "display": "Date",
             "formula": "format_date(${ts}, 'dd MMMM yyyy')",
             "filter": {
@@ -422,8 +422,7 @@
                 "key": [
                   {
                     "id": "$ref:ts",
-                    "display": "Date",
-                    "type": "timestamp"
+                    "display": "Date"
                   },
                   {
                     "id": "$ref:prison_code",
@@ -433,8 +432,7 @@
                 "measure": [
                   {
                     "id": "$ref:ts",
-                    "display": "Date",
-                    "type": "timestamp"
+                    "display": "Date"
                   },
                   {
                     "id": "$ref:appointment_count",
@@ -504,8 +502,7 @@
                 "measure": [
                   {
                     "id": "$ref:ts",
-                    "display": "Date",
-                    "type": "timestamp"
+                    "display": "Date"
                   },
                   {
                     "id": "$ref:appointments",
@@ -529,8 +526,7 @@
                 "measure": [
                   {
                     "id": "$ref:ts",
-                    "display": "Date",
-                    "type": "timestamp"
+                    "display": "Date"
                   },
                   {
                     "id": "$ref:attendees",
@@ -554,8 +550,7 @@
                 "measure": [
                   {
                     "id": "$ref:ts",
-                    "display": "Date",
-                    "type": "timestamp"
+                    "display": "Date"
                   },
                   {
                     "id": "$ref:attended_pct",
@@ -579,8 +574,7 @@
                 "measure": [
                   {
                     "id": "$ref:ts",
-                    "display": "Date",
-                    "type": "timestamp"
+                    "display": "Date"
                   },
                   {
                     "id": "$ref:non_attended_pct",
@@ -604,8 +598,7 @@
                 "measure": [
                   {
                     "id": "$ref:ts",
-                    "display": "Date",
-                    "type": "timestamp"
+                    "display": "Date"
                   },
                   {
                     "id": "$ref:not_recorded_pct",
@@ -629,8 +622,7 @@
                 "measure": [
                   {
                     "id": "$ref:ts",
-                    "display": "Date",
-                    "type": "timestamp"
+                    "display": "Date"
                   },
                   {
                     "id": "$ref:tier1_pct",
@@ -654,8 +646,7 @@
                 "measure": [
                   {
                     "id": "$ref:ts",
-                    "display": "Date",
-                    "type": "timestamp"
+                    "display": "Date"
                   },
                   {
                     "id": "$ref:tier2_pct",
@@ -679,8 +670,7 @@
                 "measure": [
                   {
                     "id": "$ref:ts",
-                    "display": "Date",
-                    "type": "timestamp"
+                    "display": "Date"
                   },
                   {
                     "id": "$ref:cancellations",

--- a/dpd/test/definitions/prisons/orphanage/act-appointment-by-caseload.json
+++ b/dpd/test/definitions/prisons/orphanage/act-appointment-by-caseload.json
@@ -431,7 +431,7 @@
                   {
                     "id": "$ref:ts",
                     "display": "Date",
-                    "type": "date"
+                    "type": "timestamp"
                   },
                   {
                     "id": "$ref:prison_code",
@@ -442,7 +442,7 @@
                   {
                     "id": "$ref:ts",
                     "display": "Date",
-                    "type": "date"
+                    "type": "timestamp"
                   },
                   {
                     "id": "$ref:appointment_count",
@@ -513,7 +513,7 @@
                   {
                     "id": "$ref:ts",
                     "display": "Date",
-                    "type": "date"
+                    "type": "timestamp"
                   },
                   {
                     "id": "$ref:appointments",
@@ -538,7 +538,7 @@
                   {
                     "id": "$ref:ts",
                     "display": "Date",
-                    "type": "date"
+                    "type": "timestamp"
                   },
                   {
                     "id": "$ref:attendees",
@@ -563,7 +563,7 @@
                   {
                     "id": "$ref:ts",
                     "display": "Date",
-                    "type": "date"
+                    "type": "timestamp"
                   },
                   {
                     "id": "$ref:attended_pct",
@@ -588,7 +588,7 @@
                   {
                     "id": "$ref:ts",
                     "display": "Date",
-                    "type": "date"
+                    "type": "timestamp"
                   },
                   {
                     "id": "$ref:non_attended_pct",
@@ -613,7 +613,7 @@
                   {
                     "id": "$ref:ts",
                     "display": "Date",
-                    "type": "date"
+                    "type": "timestamp"
                   },
                   {
                     "id": "$ref:not_recorded_pct",
@@ -638,7 +638,7 @@
                   {
                     "id": "$ref:ts",
                     "display": "Date",
-                    "type": "date"
+                    "type": "timestamp"
                   },
                   {
                     "id": "$ref:tier1_pct",
@@ -663,7 +663,7 @@
                   {
                     "id": "$ref:ts",
                     "display": "Date",
-                    "type": "date"
+                    "type": "timestamp"
                   },
                   {
                     "id": "$ref:tier2_pct",
@@ -688,7 +688,7 @@
                   {
                     "id": "$ref:ts",
                     "display": "Date",
-                    "type": "date"
+                    "type": "timestamp"
                   },
                   {
                     "id": "$ref:cancellations",

--- a/dpd/test/definitions/prisons/orphanage/act-appointment-by-caseload.json
+++ b/dpd/test/definitions/prisons/orphanage/act-appointment-by-caseload.json
@@ -142,7 +142,7 @@
         "field": [
           {
             "name": "ts",
-            "type": "date",
+            "type": "timestamp",
             "display": "Date",
             "formula": "format_date(${ts}, 'dd MMMM yyyy')",
             "filter": {
@@ -430,8 +430,7 @@
                 "key": [
                   {
                     "id": "$ref:ts",
-                    "display": "Date",
-                    "type": "timestamp"
+                    "display": "Date"
                   },
                   {
                     "id": "$ref:prison_code",
@@ -441,8 +440,7 @@
                 "measure": [
                   {
                     "id": "$ref:ts",
-                    "display": "Date",
-                    "type": "timestamp"
+                    "display": "Date"
                   },
                   {
                     "id": "$ref:appointment_count",
@@ -512,8 +510,7 @@
                 "measure": [
                   {
                     "id": "$ref:ts",
-                    "display": "Date",
-                    "type": "timestamp"
+                    "display": "Date"
                   },
                   {
                     "id": "$ref:appointments",
@@ -537,8 +534,7 @@
                 "measure": [
                   {
                     "id": "$ref:ts",
-                    "display": "Date",
-                    "type": "timestamp"
+                    "display": "Date"
                   },
                   {
                     "id": "$ref:attendees",
@@ -562,8 +558,7 @@
                 "measure": [
                   {
                     "id": "$ref:ts",
-                    "display": "Date",
-                    "type": "timestamp"
+                    "display": "Date"
                   },
                   {
                     "id": "$ref:attended_pct",
@@ -587,8 +582,7 @@
                 "measure": [
                   {
                     "id": "$ref:ts",
-                    "display": "Date",
-                    "type": "timestamp"
+                    "display": "Date"
                   },
                   {
                     "id": "$ref:non_attended_pct",
@@ -612,8 +606,7 @@
                 "measure": [
                   {
                     "id": "$ref:ts",
-                    "display": "Date",
-                    "type": "timestamp"
+                    "display": "Date"
                   },
                   {
                     "id": "$ref:not_recorded_pct",
@@ -637,8 +630,7 @@
                 "measure": [
                   {
                     "id": "$ref:ts",
-                    "display": "Date",
-                    "type": "timestamp"
+                    "display": "Date"
                   },
                   {
                     "id": "$ref:tier1_pct",
@@ -662,8 +654,7 @@
                 "measure": [
                   {
                     "id": "$ref:ts",
-                    "display": "Date",
-                    "type": "timestamp"
+                    "display": "Date"
                   },
                   {
                     "id": "$ref:tier2_pct",
@@ -687,8 +678,7 @@
                 "measure": [
                   {
                     "id": "$ref:ts",
-                    "display": "Date",
-                    "type": "timestamp"
+                    "display": "Date"
                   },
                   {
                     "id": "$ref:cancellations",

--- a/dpd/test/definitions/prisons/orphanage/act-appointment-by-caseload.json
+++ b/dpd/test/definitions/prisons/orphanage/act-appointment-by-caseload.json
@@ -430,7 +430,8 @@
                 "key": [
                   {
                     "id": "$ref:ts",
-                    "display": "Date"
+                    "display": "Date",
+                    "type": "date"
                   },
                   {
                     "id": "$ref:prison_code",
@@ -440,7 +441,8 @@
                 "measure": [
                   {
                     "id": "$ref:ts",
-                    "display": "Date"
+                    "display": "Date",
+                    "type": "date"
                   },
                   {
                     "id": "$ref:appointment_count",
@@ -510,7 +512,8 @@
                 "measure": [
                   {
                     "id": "$ref:ts",
-                    "display": "Date"
+                    "display": "Date",
+                    "type": "date"
                   },
                   {
                     "id": "$ref:appointments",
@@ -534,7 +537,8 @@
                 "measure": [
                   {
                     "id": "$ref:ts",
-                    "display": "Date"
+                    "display": "Date",
+                    "type": "date"
                   },
                   {
                     "id": "$ref:attendees",
@@ -558,7 +562,8 @@
                 "measure": [
                   {
                     "id": "$ref:ts",
-                    "display": "Date"
+                    "display": "Date",
+                    "type": "date"
                   },
                   {
                     "id": "$ref:attended_pct",
@@ -582,7 +587,8 @@
                 "measure": [
                   {
                     "id": "$ref:ts",
-                    "display": "Date"
+                    "display": "Date",
+                    "type": "date"
                   },
                   {
                     "id": "$ref:non_attended_pct",
@@ -606,7 +612,8 @@
                 "measure": [
                   {
                     "id": "$ref:ts",
-                    "display": "Date"
+                    "display": "Date",
+                    "type": "date"
                   },
                   {
                     "id": "$ref:not_recorded_pct",
@@ -630,7 +637,8 @@
                 "measure": [
                   {
                     "id": "$ref:ts",
-                    "display": "Date"
+                    "display": "Date",
+                    "type": "date"
                   },
                   {
                     "id": "$ref:tier1_pct",
@@ -654,7 +662,8 @@
                 "measure": [
                   {
                     "id": "$ref:ts",
-                    "display": "Date"
+                    "display": "Date",
+                    "type": "date"
                   },
                   {
                     "id": "$ref:tier2_pct",
@@ -678,7 +687,8 @@
                 "measure": [
                   {
                     "id": "$ref:ts",
-                    "display": "Date"
+                    "display": "Date",
+                    "type": "date"
                   },
                   {
                     "id": "$ref:cancellations",


### PR DESCRIPTION
- The FE no longer depends on a dataset column with the name `ts` to determines the timestamp
- The FE now looks for a column in the vis def with the type of `timestamp`
- This will be set by the field type in the dataset
- This PR updates the DPD's that use the ID `ts` to also have the `type: 'timestamp'` field set in the dataset