### PR TITLE
MAPA-149 Cover all transaction types in Location transactions filter

### DIFF
--- a/dpd/dev/definitions/prisons/orphanage/locations-inside-prison-tx.json
+++ b/dpd/dev/definitions/prisons/orphanage/locations-inside-prison-tx.json
@@ -208,7 +208,6 @@
             "filter": {
               "type": "multiselect",
               "interactive": true,
-              "default": "LOCATION_CREATE,LOCATION_UPDATE,CAPACITY_CHANGE,CELL_TYPE_CHANGES,DEACTIVATION,PERMANENT_DEACTIVATION,REACTIVATION,CELL_CONVERTION_TO_ROOM,ROOM_CONVERTION_TO_CELL,SIGNED_OP_CAP,RESI_SERVICE_ACTIVATION",
               "staticoptions": [
                 {"name": "LOCATION_CREATE", "display": "Created residential location"},
                 {"name": "LOCATION_UPDATE", "display": "Updated residential location"},
@@ -223,12 +222,14 @@
                 {"name": "ROOM_CONVERTION_TO_CELL", "display": "Room conversion to cell"},
                 {"name": "SIGNED_OP_CAP", "display": "Signed operational capacity"},
                 {"name": "RESI_SERVICE_ACTIVATION", "display": "Residential service activation"},
+                {"name": "NON_RESI_SERVICE_ACTIVATION", "display": "Non-residential service activation"},
+                {"name": "INCLUDE_SEG_IN_ROLL_COUNT_ACTIVATION", "display": "Include segregation in roll count activation"},
                 {"name": "APPROVAL_PROCESS_ACTIVATION", "display": "Certification approval activation"},
-                {"name": "PENDING_CELL_CHANGE", "display": "Certification approval activation"},
                 {"name": "REQUEST_CERTIFICATION_APPROVAL", "display": "Request certification approval"},
                 {"name": "APPROVE_CERTIFICATION_REQUEST", "display": "Approve request"},
                 {"name": "REJECT_CERTIFICATION_REQUEST", "display": "Reject request"},
                 {"name": "WITHDRAW_CERTIFICATION_REQUEST", "display": "Withdraw request"},
+                {"name": "CERTIFICATE_BASELINE", "display": "Certificate baseline"},
                 {"name": "SYNC", "display": "NOMIS sync (Residential)"},
                 {"name": "SYNC_NON_RESIDENTIAL", "display": "NOMIS sync (Non-Residential)"},
                 {"name": "DELETE", "display": "Locations deleted"}

--- a/dpd/preprod/definitions/prisons/orphanage/locations-inside-prison-tx.json
+++ b/dpd/preprod/definitions/prisons/orphanage/locations-inside-prison-tx.json
@@ -208,7 +208,6 @@
             "filter": {
               "type": "multiselect",
               "interactive": true,
-              "default": "LOCATION_CREATE,LOCATION_UPDATE,CAPACITY_CHANGE,CELL_TYPE_CHANGES,DEACTIVATION,PERMANENT_DEACTIVATION,REACTIVATION,CELL_CONVERTION_TO_ROOM,ROOM_CONVERTION_TO_CELL,SIGNED_OP_CAP,RESI_SERVICE_ACTIVATION",
               "staticoptions": [
                 {"name": "LOCATION_CREATE", "display": "Created residential location"},
                 {"name": "LOCATION_UPDATE", "display": "Updated residential location"},
@@ -223,12 +222,14 @@
                 {"name": "ROOM_CONVERTION_TO_CELL", "display": "Room conversion to cell"},
                 {"name": "SIGNED_OP_CAP", "display": "Signed operational capacity"},
                 {"name": "RESI_SERVICE_ACTIVATION", "display": "Residential service activation"},
+                {"name": "NON_RESI_SERVICE_ACTIVATION", "display": "Non-residential service activation"},
+                {"name": "INCLUDE_SEG_IN_ROLL_COUNT_ACTIVATION", "display": "Include segregation in roll count activation"},
                 {"name": "APPROVAL_PROCESS_ACTIVATION", "display": "Certification approval activation"},
-                {"name": "PENDING_CELL_CHANGE", "display": "Certification approval activation"},
                 {"name": "REQUEST_CERTIFICATION_APPROVAL", "display": "Request certification approval"},
                 {"name": "APPROVE_CERTIFICATION_REQUEST", "display": "Approve request"},
                 {"name": "REJECT_CERTIFICATION_REQUEST", "display": "Reject request"},
                 {"name": "WITHDRAW_CERTIFICATION_REQUEST", "display": "Withdraw request"},
+                {"name": "CERTIFICATE_BASELINE", "display": "Certificate baseline"},
                 {"name": "SYNC", "display": "NOMIS sync (Residential)"},
                 {"name": "SYNC_NON_RESIDENTIAL", "display": "NOMIS sync (Non-Residential)"},
                 {"name": "DELETE", "display": "Locations deleted"}

--- a/dpd/prod/definitions/prisons/orphanage/locations-inside-prison-tx.json
+++ b/dpd/prod/definitions/prisons/orphanage/locations-inside-prison-tx.json
@@ -208,7 +208,6 @@
             "filter": {
               "type": "multiselect",
               "interactive": true,
-              "default": "LOCATION_CREATE,LOCATION_UPDATE,CAPACITY_CHANGE,CELL_TYPE_CHANGES,DEACTIVATION,PERMANENT_DEACTIVATION,REACTIVATION,CELL_CONVERTION_TO_ROOM,ROOM_CONVERTION_TO_CELL,SIGNED_OP_CAP,RESI_SERVICE_ACTIVATION",
               "staticoptions": [
                 {"name": "LOCATION_CREATE", "display": "Created residential location"},
                 {"name": "LOCATION_UPDATE", "display": "Updated residential location"},
@@ -223,12 +222,14 @@
                 {"name": "ROOM_CONVERTION_TO_CELL", "display": "Room conversion to cell"},
                 {"name": "SIGNED_OP_CAP", "display": "Signed operational capacity"},
                 {"name": "RESI_SERVICE_ACTIVATION", "display": "Residential service activation"},
+                {"name": "NON_RESI_SERVICE_ACTIVATION", "display": "Non-residential service activation"},
+                {"name": "INCLUDE_SEG_IN_ROLL_COUNT_ACTIVATION", "display": "Include segregation in roll count activation"},
                 {"name": "APPROVAL_PROCESS_ACTIVATION", "display": "Certification approval activation"},
-                {"name": "PENDING_CELL_CHANGE", "display": "Certification approval activation"},
                 {"name": "REQUEST_CERTIFICATION_APPROVAL", "display": "Request certification approval"},
                 {"name": "APPROVE_CERTIFICATION_REQUEST", "display": "Approve request"},
                 {"name": "REJECT_CERTIFICATION_REQUEST", "display": "Reject request"},
                 {"name": "WITHDRAW_CERTIFICATION_REQUEST", "display": "Withdraw request"},
+                {"name": "CERTIFICATE_BASELINE", "display": "Certificate baseline"},
                 {"name": "SYNC", "display": "NOMIS sync (Residential)"},
                 {"name": "SYNC_NON_RESIDENTIAL", "display": "NOMIS sync (Non-Residential)"},
                 {"name": "DELETE", "display": "Locations deleted"}

--- a/dpd/test/definitions/prisons/orphanage/locations-inside-prison-tx.json
+++ b/dpd/test/definitions/prisons/orphanage/locations-inside-prison-tx.json
@@ -208,7 +208,6 @@
             "filter": {
               "type": "multiselect",
               "interactive": true,
-              "default": "LOCATION_CREATE,LOCATION_UPDATE,CAPACITY_CHANGE,CELL_TYPE_CHANGES,DEACTIVATION,PERMANENT_DEACTIVATION,REACTIVATION,CELL_CONVERTION_TO_ROOM,ROOM_CONVERTION_TO_CELL,SIGNED_OP_CAP,RESI_SERVICE_ACTIVATION",
               "staticoptions": [
                 {"name": "LOCATION_CREATE", "display": "Created residential location"},
                 {"name": "LOCATION_UPDATE", "display": "Updated residential location"},
@@ -223,12 +222,14 @@
                 {"name": "ROOM_CONVERTION_TO_CELL", "display": "Room conversion to cell"},
                 {"name": "SIGNED_OP_CAP", "display": "Signed operational capacity"},
                 {"name": "RESI_SERVICE_ACTIVATION", "display": "Residential service activation"},
+                {"name": "NON_RESI_SERVICE_ACTIVATION", "display": "Non-residential service activation"},
+                {"name": "INCLUDE_SEG_IN_ROLL_COUNT_ACTIVATION", "display": "Include segregation in roll count activation"},
                 {"name": "APPROVAL_PROCESS_ACTIVATION", "display": "Certification approval activation"},
-                {"name": "PENDING_CELL_CHANGE", "display": "Certification approval activation"},
                 {"name": "REQUEST_CERTIFICATION_APPROVAL", "display": "Request certification approval"},
                 {"name": "APPROVE_CERTIFICATION_REQUEST", "display": "Approve request"},
                 {"name": "REJECT_CERTIFICATION_REQUEST", "display": "Reject request"},
                 {"name": "WITHDRAW_CERTIFICATION_REQUEST", "display": "Withdraw request"},
+                {"name": "CERTIFICATE_BASELINE", "display": "Certificate baseline"},
                 {"name": "SYNC", "display": "NOMIS sync (Residential)"},
                 {"name": "SYNC_NON_RESIDENTIAL", "display": "NOMIS sync (Non-Residential)"},
                 {"name": "DELETE", "display": "Locations deleted"}


### PR DESCRIPTION
Syncs the **Transaction type** filter on the "Location transactions" report with the `TransactionType` enum in `hmpps-locations-inside-prison-api`, across dev/test/preprod/prod.

- Added `NON_RESI_SERVICE_ACTIVATION`, `INCLUDE_SEG_IN_ROLL_COUNT_ACTIVATION`, `CERTIFICATE_BASELINE`
- Removed stale `PENDING_CELL_CHANGE` (not a valid enum value, duplicate label)
- Removed the default pre-selection so the filter shows all transaction types

Filter now matches the enum exactly (24/24); `npm run validate` and `npm run uniqueness` pass.