### PR TITLE
PDHD-271 added bulk delete workflow

### DIFF
--- a/.github/workflows/bulk-delete.yml
+++ b/.github/workflows/bulk-delete.yml
@@ -1,0 +1,69 @@
+name: Bulk-Delete
+
+on:
+  workflow_dispatch:
+    inputs:
+      deployEnv:
+        description: "Environment to delete DPDs from"
+        required: true
+        default: dev
+        type: choice
+        options:
+          - dev
+          - test
+          - preprod
+          - prod
+
+      dpdIds:
+        description: "Comma-separated DPD IDs (e.g. id1,id2,id3)"
+        required: true
+        type: text
+
+      category:
+        description: "DPD Category/Path"
+        required: true
+        type: text
+
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  delete-dpd:
+    name: Delete DPDs from ${{ inputs.deployEnv }} env
+    environment: ${{ inputs.deployEnv }}
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@254c19bd240aabef8777f48595e9d2d7b972184b # v6.2.1
+        with:
+          role-to-assume: "arn:aws:iam::${{ secrets.ACCOUNT_NUMBER }}:role/dpr-dpd-table-github-deploy-role"
+          role-session-name: githubactionsrolesession
+          aws-region: "eu-west-2"
+
+      - name: Delete DPDs from DynamoDB
+        shell: bash
+        run: |
+          IFS=',' read -ra dpdIds <<< "${{ inputs.dpdIds }}"
+
+          for dpdId in "${dpdIds[@]}"; do
+            # Trim leading/trailing whitespace
+            dpdId=$(echo "$dpdId" | xargs)
+
+            # Skip empty values
+            if [[ -z "$dpdId" ]]; then
+              continue
+            fi
+
+            echo "Deleting DPD: $dpdId (category: ${{ inputs.category }})"
+
+            aws dynamodb delete-item \
+              --table-name dpr-data-product-definition \
+              --key "{
+                \"data-product-id\": { \"S\": \"$dpdId\" },
+                \"category\": { \"S\": \"${{ inputs.category }}\" }
+              }"
+          done

--- a/.github/workflows/bulk-delete.yml
+++ b/.github/workflows/bulk-delete.yml
@@ -47,6 +47,9 @@ jobs:
       - name: Delete DPDs from DynamoDB
         shell: bash
         run: |
+          failed=0
+          failedDpds=()
+
           IFS=',' read -ra dpdIds <<< "${{ inputs.dpdIds }}"
 
           for dpdId in "${dpdIds[@]}"; do
@@ -60,10 +63,23 @@ jobs:
 
             echo "Deleting DPD: $dpdId (category: ${{ inputs.category }})"
 
-            aws dynamodb delete-item \
+            if ! aws dynamodb delete-item \
               --table-name dpr-data-product-definition \
               --key "{
                 \"data-product-id\": { \"S\": \"$dpdId\" },
                 \"category\": { \"S\": \"${{ inputs.category }}\" }
-              }"
+              }"; then
+                echo "Failed to delete DPD: $dpdId"
+                failed=1
+                failedDpds+=("$dpdId")
+            fi
           done
+
+          if [[ $failed -ne 0 ]]; then
+            echo ""
+            echo "The following DPDs failed to delete:"
+            printf '%s\n' "${failedDpds[@]}"
+            exit 1
+          fi
+
+          echo "All DPDs deleted successfully."


### PR DESCRIPTION
Allow to delete DPDs from DDB in Bulk.
DDB permissions don't allow us to do this directly.
And the current workflow we have only allows deleting one at a time.
This is useful as preparation to migrating other teams' existing DPDs to their own repos.