### PR TITLE
PDHD-195 added lao policy to report0

### DIFF
--- a/dpd/dev/definitions/probation/report0.json
+++ b/dpd/dev/definitions/probation/report0.json
@@ -208,10 +208,10 @@
             "type": "lao",
             "rule": [
                 {
-                    "effect": "permit"
+                    "effect": "permit",
+                    "condition": []
                 }
-            ],
-            "condition": []
+            ]
         },
         {
             "id": "access",

--- a/dpd/dev/definitions/probation/report0.json
+++ b/dpd/dev/definitions/probation/report0.json
@@ -210,7 +210,8 @@
                 {
                     "effect": "permit"
                 }
-            ]
+            ],
+            "condition": []
         },
         {
             "id": "access",

--- a/dpd/dev/definitions/probation/report0.json
+++ b/dpd/dev/definitions/probation/report0.json
@@ -204,6 +204,15 @@
     ],
     "policy": [
         {
+            "id": "lao",
+            "type": "lao",
+            "rule": [
+                {
+                    "effect": "permit"
+                }
+            ]
+        },
+        {
             "id": "access",
             "type": "access",
             "rule": [


### PR DESCRIPTION
Currently report0 is shown as unauthorised in the probation ui. 
Adding an lao permit policy to fix this.