### PR TITLE
added probation folders to preprod and prod

### DIFF
--- a/dpd/preprod/definitions/probation/empty-to-be-deleted
+++ b/dpd/preprod/definitions/probation/empty-to-be-deleted
@@ -1,0 +1,2 @@
+This file is a placeholder file so that the probation folder can be created.
+The file can be deleted when there is at least one DPD in the folder.

--- a/dpd/prod/definitions/probation/empty-to-be-deleted
+++ b/dpd/prod/definitions/probation/empty-to-be-deleted
@@ -1,0 +1,2 @@
+This file is a placeholder file so that the probation folder can be created.
+The file can be deleted when there is at least one DPD in the folder.


### PR DESCRIPTION
These changes add the probation folders to preprod and prod.
The benefit of having probation DPDs in their own folder is the publication process is much faster as only these relevant DPDs will be published when triggering the workflow. Plus this makes it consistent with Dev and Test.
Empty placeholder files were added to the folders in order to enable the git commit.
These files are ignored as the publication workflow only looks for json files and they can be deleted later. 
This is as a preparation for probation DPD publication.