### PR TITLE
Removed placeholder files from preprod and prod probation folders

### DIFF
--- a/dpd/preprod/definitions/probation/empty-to-be-deleted
+++ b/dpd/preprod/definitions/probation/empty-to-be-deleted
@@ -1,2 +1,0 @@
-This file is a placeholder file so that the probation folder can be created.
-The file can be deleted when there is at least one DPD in the folder.

--- a/dpd/prod/definitions/probation/empty-to-be-deleted
+++ b/dpd/prod/definitions/probation/empty-to-be-deleted
@@ -1,2 +1,0 @@
-This file is a placeholder file so that the probation folder can be created.
-The file can be deleted when there is at least one DPD in the folder.


### PR DESCRIPTION
These files were placeholders to allow the probation folders to be committed to git. 
Now that actual DPD files exist they are no longer needed.